### PR TITLE
Add robots.txt and update docfx.json to include it

### DIFF
--- a/Documentation/docfx.json
+++ b/Documentation/docfx.json
@@ -30,7 +30,7 @@
     ],
     "resource": [
       {
-        "files": ["images/**", "favicon.ico", "logo.svg"]
+        "files": ["images/**", "favicon.ico", "logo.svg", "robots.txt"]
       }
     ],
     "overwrite": [

--- a/Documentation/robots.txt
+++ b/Documentation/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /*?
+
+Sitemap: https://netcord.dev/sitemap.xml


### PR DESCRIPTION
Updated `docfx.json` to include `robots.txt` in the list of resource files. Added a new `robots.txt` file that:
- Allows all user agents.
- Disallows crawling of URLs with query strings.
- Specifies the sitemap location at `https://netcord.dev/sitemap.xml`.