### PR TITLE
Optimize memory allocation using ArrayPool

### DIFF
--- a/NetCord/Gateway/Voice/Streams/DecryptStream.cs
+++ b/NetCord/Gateway/Voice/Streams/DecryptStream.cs
@@ -67,30 +67,47 @@ internal class DecryptStream(Stream next, IVoiceEncryption encryption) : Rewriti
 
         async ValueTask ActualWriteAsync()
         {
-            using (Decrypt(out var plaintext))
-                await _next.WriteAsync(plaintext, cancellationToken).ConfigureAwait(false);
+            var array = Decrypt(out var plaintext);
 
-            IMemoryOwner<byte> Decrypt(out Memory<byte> plaintext)
+            await _next.WriteAsync(plaintext, cancellationToken).ConfigureAwait(false);
+
+            ArrayPool<byte>.Shared.Return(array);
+
+            byte[] Decrypt(out Memory<byte> plaintext)
             {
                 var packet = packetStorage.Packet;
 
                 var extension = packet.Extension;
 
-                int plaintextLength = extension && !_extensionEncryption ? buffer.Length - _expansion - 4 : buffer.Length - _expansion;
+                int plaintextLength = extension && !_extensionEncryption
+                    ? buffer.Length - _expansion - 4
+                    : buffer.Length - _expansion;
 
-                var owner = MemoryPool<byte>.Shared.Rent(plaintextLength);
-                plaintext = owner.Memory[..plaintextLength];
-                var plaintextSpan = plaintext.Span;
+                var array = ArrayPool<byte>.Shared.Rent(plaintextLength);
+
+                var plaintextSpan = array.AsSpan(0, plaintextLength);
 
                 encryption.Decrypt(packet, plaintextSpan);
 
+                int start, length;
                 if (extension)
                 {
-                    int extensionLength = _extensionEncryption ? BinaryPrimitives.ReadUInt16BigEndian(plaintextSpan[2..]) + 1 : BinaryPrimitives.ReadUInt16BigEndian(packet.Datagram[(packet.HeaderLength + 2)..]);
-                    plaintext = plaintext[(4 * extensionLength)..];
+                    int extensionLength = _extensionEncryption
+                        ? BinaryPrimitives.ReadUInt16BigEndian(plaintextSpan[2..]) + 1
+                        : BinaryPrimitives.ReadUInt16BigEndian(packet.Datagram[(packet.HeaderLength + 2)..]);
+
+                    start = 4 * extensionLength;
+                    length = plaintextLength - start;
+                }
+                else
+                {
+                    start = 0;
+                    length = plaintextLength;
                 }
 
-                return owner;
+                plaintext = array.AsMemory(start, length);
+
+                return array;
             }
         }
     }
@@ -135,19 +152,27 @@ internal class DecryptStream(Stream next, IVoiceEncryption encryption) : Rewriti
 
         var extension = packet.Extension;
 
-        int plaintextLength = extension && !_extensionEncryption ? buffer.Length - _expansion - 4 : buffer.Length - _expansion;
+        int plaintextLength = extension && !_extensionEncryption
+            ? buffer.Length - _expansion - 4
+            : buffer.Length - _expansion;
 
-        var owner = MemoryPool<byte>.Shared.Rent(plaintextLength);
-        var plaintext = owner.Memory.Span[..plaintextLength];
+        var array = ArrayPool<byte>.Shared.Rent(plaintextLength);
+
+        var plaintext = array.AsSpan(0, plaintextLength);
 
         encryption.Decrypt(packet, plaintext);
 
         if (extension)
         {
-            int extensionLength = _extensionEncryption ? BinaryPrimitives.ReadUInt16BigEndian(plaintext[2..]) + 1 : BinaryPrimitives.ReadUInt16BigEndian(packet.Datagram[(packet.HeaderLength + 2)..]);
+            int extensionLength = _extensionEncryption
+                ? BinaryPrimitives.ReadUInt16BigEndian(plaintext[2..]) + 1
+                : BinaryPrimitives.ReadUInt16BigEndian(packet.Datagram[(packet.HeaderLength + 2)..]);
+
             plaintext = plaintext[(4 * extensionLength)..];
         }
 
         _next.Write(plaintext);
+
+        ArrayPool<byte>.Shared.Return(array);
     }
 }

--- a/NetCord/Gateway/Voice/Streams/EncryptStream.cs
+++ b/NetCord/Gateway/Voice/Streams/EncryptStream.cs
@@ -16,19 +16,26 @@ internal class EncryptStream(Stream next, IVoiceEncryption encryption, VoiceClie
     public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
     {
         int datagramLength = buffer.Length + _expansion;
-        using var owner = MemoryPool<byte>.Shared.Rent(datagramLength);
-        var datagram = owner.Memory[..datagramLength];
-        WriteDatagram(buffer.Span, datagram.Span);
-        await _next.WriteAsync(datagram, cancellationToken).ConfigureAwait(false);
+
+        var array = ArrayPool<byte>.Shared.Rent(datagramLength);
+
+        WriteDatagram(buffer.Span, array.AsSpan(0, datagramLength));
+        await _next.WriteAsync(array.AsMemory(0, datagramLength), cancellationToken).ConfigureAwait(false);
+
+        ArrayPool<byte>.Shared.Return(array);
     }
 
     public override void Write(ReadOnlySpan<byte> buffer)
     {
         int datagramLength = buffer.Length + _expansion;
-        using var owner = MemoryPool<byte>.Shared.Rent(datagramLength);
-        var datagram = owner.Memory.Span[..datagramLength];
+
+        var array = ArrayPool<byte>.Shared.Rent(datagramLength);
+
+        var datagram = array.AsSpan(0, datagramLength);
         WriteDatagram(buffer, datagram);
         _next.Write(datagram);
+
+        ArrayPool<byte>.Shared.Return(array);
     }
 
     public override async Task FlushAsync(CancellationToken cancellationToken)

--- a/NetCord/Gateway/Voice/Streams/OpusDecodeStream.cs
+++ b/NetCord/Gateway/Voice/Streams/OpusDecodeStream.cs
@@ -47,18 +47,23 @@ public partial class OpusDecodeStream
 {
     public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
     {
-        using var owner = MemoryPool<byte>.Shared.Rent(_frameSize);
-        var pcm = owner.Memory[.._frameSize];
-        Decode(buffer.Span, pcm.Span);
-        await _next.WriteAsync(pcm, cancellationToken).ConfigureAwait(false);
+        var array = ArrayPool<byte>.Shared.Rent(_frameSize);
+
+        Decode(buffer.Span, array.AsSpan(0, _frameSize));
+        await _next.WriteAsync(array.AsMemory(0, _frameSize), cancellationToken).ConfigureAwait(false);
+
+        ArrayPool<byte>.Shared.Return(array);
     }
 
     public override void Write(ReadOnlySpan<byte> buffer)
     {
-        using var owner = MemoryPool<byte>.Shared.Rent(_frameSize);
-        var pcm = owner.Memory.Span[.._frameSize];
+        var array = ArrayPool<byte>.Shared.Rent(_frameSize);
+
+        var pcm = array.AsSpan(0, _frameSize);
         Decode(buffer, pcm);
         _next.Write(pcm);
+
+        ArrayPool<byte>.Shared.Return(array);
     }
 
     protected override void Dispose(bool disposing)

--- a/NetCord/Gateway/Voice/Streams/OpusEncodeStream.cs
+++ b/NetCord/Gateway/Voice/Streams/OpusEncodeStream.cs
@@ -36,7 +36,7 @@ public class OpusEncodeStream(Stream next, PcmFormat format, VoiceChannels chann
 
         public SegmentingStream(Stream next, PcmFormat format, VoiceChannels channels) : base(next)
         {
-            _buffer = new byte[_frameSize = Opus.GetFrameSize(format, channels)];
+            _buffer = GC.AllocateUninitializedArray<byte>(_frameSize = Opus.GetFrameSize(format, channels));
         }
 
         public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
@@ -156,18 +156,23 @@ public class OpusEncodeStream(Stream next, PcmFormat format, VoiceChannels chann
     {
         public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            using var owner = MemoryPool<byte>.Shared.Rent(Opus.MaxOpusFrameLength);
-            var data = owner.Memory;
-            int count = Encode(buffer.Span, data.Span);
-            await _next.WriteAsync(data[..count], cancellationToken).ConfigureAwait(false);
+            var array = ArrayPool<byte>.Shared.Rent(Opus.MaxOpusFrameLength);
+
+            int count = Encode(buffer.Span, array.AsSpan());
+            await _next.WriteAsync(array.AsMemory(0, count), cancellationToken).ConfigureAwait(false);
+
+            ArrayPool<byte>.Shared.Return(array);
         }
 
         public override void Write(ReadOnlySpan<byte> buffer)
         {
-            using var owner = MemoryPool<byte>.Shared.Rent(Opus.MaxOpusFrameLength);
-            var data = owner.Memory.Span;
+            var array = ArrayPool<byte>.Shared.Rent(Opus.MaxOpusFrameLength);
+            
+            var data = array.AsSpan();
             int count = Encode(buffer, data);
             _next.Write(data[..count]);
+
+            ArrayPool<byte>.Shared.Return(array);
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
Replaced `MemoryPool<byte>.Shared.Rent` with `ArrayPool<byte>.Shared.Rent` in `DecryptStream`, `EncryptStream`, `OpusDecodeStream`, and `OpusEncodeStream` to enhance performance.

Updated the `Decrypt` method in `DecryptStream` to return an array and adjusted plaintext length handling accordingly. Modified `WriteAsync` and `Write` methods in the other streams to utilize `ArrayPool`, ensuring efficient memory management by returning allocated arrays to the pool.

Included minor formatting improvements for better code readability.