### PR TITLE
Have a base parent for all context types so all variations can be pro…

### DIFF
--- a/NetCord.Services/Contexts/IChannelContext.cs
+++ b/NetCord.Services/Contexts/IChannelContext.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetCord.Services;
 
-public interface IChannelContext
+public interface IChannelContext : IContext
 {
     public TextChannel? Channel { get; }
 }

--- a/NetCord.Services/Contexts/IContext.cs
+++ b/NetCord.Services/Contexts/IContext.cs
@@ -1,0 +1,6 @@
+namespace Netcord.Services;
+
+public interface IContext
+{
+
+}

--- a/NetCord.Services/Contexts/IContext.cs
+++ b/NetCord.Services/Contexts/IContext.cs
@@ -2,5 +2,4 @@ namespace NetCord.Services;
 
 public interface IContext
 {
-
 }

--- a/NetCord.Services/Contexts/IContext.cs
+++ b/NetCord.Services/Contexts/IContext.cs
@@ -1,4 +1,4 @@
-namespace Netcord.Services;
+namespace NetCord.Services;
 
 public interface IContext
 {

--- a/NetCord.Services/Contexts/IGatewayClientContext.cs
+++ b/NetCord.Services/Contexts/IGatewayClientContext.cs
@@ -2,7 +2,7 @@
 
 namespace NetCord.Services;
 
-public interface IGatewayClientContext
+public interface IGatewayClientContext : IContext
 {
     public GatewayClient Client { get; }
 }

--- a/NetCord.Services/Contexts/IGuildContext.cs
+++ b/NetCord.Services/Contexts/IGuildContext.cs
@@ -2,7 +2,7 @@
 
 namespace NetCord.Services;
 
-public interface IGuildContext
+public interface IGuildContext : IContext
 {
     public Guild? Guild { get; }
 

--- a/NetCord.Services/Contexts/IInteractionContext.cs
+++ b/NetCord.Services/Contexts/IInteractionContext.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetCord.Services;
 
-public interface IInteractionContext
+public interface IInteractionContext : IContext
 {
     public Interaction Interaction { get; }
 }

--- a/NetCord.Services/Contexts/IRestClientContext.cs
+++ b/NetCord.Services/Contexts/IRestClientContext.cs
@@ -2,7 +2,7 @@
 
 namespace NetCord.Services;
 
-public interface IRestClientContext
+public interface IRestClientContext : IContext
 {
     public RestClient Client { get; }
 }

--- a/NetCord.Services/Contexts/IRestMessageContext.cs
+++ b/NetCord.Services/Contexts/IRestMessageContext.cs
@@ -2,7 +2,7 @@
 
 namespace NetCord.Services;
 
-public interface IRestMessageContext
+public interface IRestMessageContext : IContext
 {
     public RestMessage Message { get; }
 }

--- a/NetCord.Services/Contexts/IUserContext.cs
+++ b/NetCord.Services/Contexts/IUserContext.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetCord.Services;
 
-public interface IUserContext
+public interface IUserContext : IContext
 {
     public User User { get; }
 }


### PR DESCRIPTION
…pagated as a single shared parent.

## Reason

When writing shared services for different modules, for similar reason as `IMessageProperties`, `IContext` can serve as a propagated shared parent between all context types. This allows generic constraints to accept any context type regardless of scope, and allows complete non-generic context access for all situations.

## Loss?

No, it's an empty interface with no goal other than boxing and casting if a user desires it. If Netcord chooses not to implement it in the base functionality, it will not make any impact.

## Potential future uses

As formerly discussed in the Discord channels, it is considered to write access to the context like `IHttpContextAccessor`, but instead for `IContextAccessor<T>`, where T would be constrained to... `IContext`, potentially.