### PR TITLE
Add MinVer for automatic version management

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,9 +2,9 @@ name: Build and Publish
 
 on:
   push:
-    branches:
-      - stable
-      - alpha
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
 
 jobs:
   build-and-publish:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -12,6 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+         fetch-depth: 0
+         filter: tree:0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+         fetch-depth: 0
+         filter: tree:0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/Hosting/NetCord.Hosting.AspNetCore/NetCord.Hosting.AspNetCore.csproj
+++ b/Hosting/NetCord.Hosting.AspNetCore/NetCord.Hosting.AspNetCore.csproj
@@ -12,8 +12,6 @@
     <PackageTags>bot;discord;discord-api</PackageTags>
     <PackageIcon>SmallSquare.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>$(VersionPrefix)</Version>
-    <VersionSuffix>alpha.370</VersionSuffix>
     <Description>The modern and fully customizable C# Discord library.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -22,6 +20,10 @@
   <ItemGroup>
     <None Include="..\..\Resources\NuGet\README.md" Pack="true" PackagePath="" />
     <None Include="..\..\Resources\Logo\png\SmallSquare.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Hosting/NetCord.Hosting.Services/NetCord.Hosting.Services.csproj
+++ b/Hosting/NetCord.Hosting.Services/NetCord.Hosting.Services.csproj
@@ -8,14 +8,12 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsAotCompatible>true</IsAotCompatible>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
-    
+
     <RepositoryUrl>https://github.com/NetCordDev/NetCord</RepositoryUrl>
     <PackageProjectUrl>https://netcord.dev</PackageProjectUrl>
     <PackageTags>bot;discord;discord-api</PackageTags>
     <PackageIcon>SmallSquare.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>$(VersionPrefix)</Version>
-    <VersionSuffix>alpha.370</VersionSuffix>
     <Description>The modern and fully customizable C# Discord library.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -28,6 +26,10 @@
   <ItemGroup>
     <None Include="..\..\Resources\NuGet\README.md" Pack="true" PackagePath="" />
     <None Include="..\..\Resources\Logo\png\SmallSquare.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Hosting/NetCord.Hosting/NetCord.Hosting.csproj
+++ b/Hosting/NetCord.Hosting/NetCord.Hosting.csproj
@@ -13,8 +13,6 @@
     <PackageTags>bot;discord;discord-api</PackageTags>
     <PackageIcon>SmallSquare.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>$(VersionPrefix)</Version>
-    <VersionSuffix>alpha.370</VersionSuffix>
     <Description>The modern and fully customizable C# Discord library.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -32,6 +30,10 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NetCord.Services/NetCord.Services.csproj
+++ b/NetCord.Services/NetCord.Services.csproj
@@ -13,8 +13,6 @@
     <PackageTags>bot;discord;discord-api</PackageTags>
     <PackageIcon>SmallSquare.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>$(VersionPrefix)</Version>
-    <VersionSuffix>alpha.370</VersionSuffix>
     <Description>The modern and fully customizable C# Discord library.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -28,7 +26,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\NetCord\NetCord.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/NetCord/NetCord.csproj
+++ b/NetCord/NetCord.csproj
@@ -13,18 +13,20 @@
     <PackageTags>bot;discord;discord-api</PackageTags>
     <PackageIcon>SmallSquare.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>$(VersionPrefix)</Version>
-    <VersionSuffix>alpha.370</VersionSuffix>
     <Description>The modern and fully customizable C# Discord library.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    
+
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\Resources\NuGet\README.md" Pack="true" PackagePath="" />
     <None Include="..\Resources\Logo\png\SmallSquare.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds MinVer to the repo to handle versioning instead of doing it manually.

Once this is merged, the latest previously released commit should be tagged with the version number to get MinVer up to speed on the current versioning.

I've changed the Build and Publish workflow to instead be triggered by pushing a version tag to the repo. This means that releasing will now be a separate step from merging any PR, giving you more control over when to push a new version.

I do see that you have documentation that gets generated as well, but I didn't dig too deeply into how that works. If you still want preview documentation to get published for any merge to the default branch, it probably makes sense to split that out into a separate workflow that could still be triggered on push to the branch.

Let me know what you think of the changes or if there's anything else you want more of an explanation about.