### PR TITLE
Rename concurrency groups in YAML workflows

### DIFF
--- a/.github/workflows/cleanup-documentation-preview.yml
+++ b/.github/workflows/cleanup-documentation-preview.yml
@@ -5,7 +5,7 @@ on:
     types: [closed]
 
 concurrency:
-  group: documentation preview ${{ github.ref_name }}
+  group: documentation-preview-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/documentation-preview.yml
+++ b/.github/workflows/documentation-preview.yml
@@ -6,7 +6,7 @@ on:
     types: [completed]
 
 concurrency:
-  group: documentation preview ${{ github.event.workflow_run.head_branch }}
+  group: documentation-preview-${{ github.event.workflow_run.head_branch }}
 
 jobs:
   documentation-preview:


### PR DESCRIPTION
Updated concurrency group names in `cleanup-documentation-preview.yml` and `documentation-preview.yml` to replace spaces with hyphens for improved consistency.