### PR TITLE
Refactor localization handling in RestRequestProperties

### DIFF
--- a/NetCord/Rest/RestRequestProperties.cs
+++ b/NetCord/Rest/RestRequestProperties.cs
@@ -13,9 +13,9 @@ public sealed partial class RestRequestProperties
     public string? AuditLogReason { get; set; }
 
     /// <summary>
-    /// The error localization. This is used to localize error messages returned by Discord.
+    /// The localization used for data returned by Discord.
     /// </summary>
-    public string? ErrorLocalization { get; set; }
+    public string? Localization { get; set; }
 
     internal readonly record struct RestRequestHeaderInfo(string Name, IEnumerable<string> Values);
 
@@ -25,8 +25,8 @@ public sealed partial class RestRequestProperties
         if (auditLogReason is not null)
             yield return new("X-Audit-Log-Reason", [Uri.EscapeDataString(auditLogReason)]);
 
-        var errorLocalization = ErrorLocalization;
-        if (errorLocalization is not null)
-            yield return new("Accept-Language", [Uri.EscapeDataString(errorLocalization)]);
+        var localization = Localization;
+        if (localization is not null)
+            yield return new("Accept-Language", [Uri.EscapeDataString(localization)]);
     }
 }


### PR DESCRIPTION
Removed the `ErrorLocalization` property and introduced a new `Localization` property for better clarity. Updated documentation and modified the `GetHeaders` method to utilize the new `Localization` property for the "Accept-Language" header.