### PR TITLE
Added `DeferAsync` method to base Modules

### DIFF
--- a/NetCord.Services/ApplicationCommands/ApplicationCommandModule.cs
+++ b/NetCord.Services/ApplicationCommands/ApplicationCommandModule.cs
@@ -4,6 +4,8 @@ namespace NetCord.Services.ApplicationCommands;
 
 public class ApplicationCommandModule<TContext> : BaseApplicationCommandModule<TContext> where TContext : IApplicationCommandContext
 {
+    public Task<InteractionCallbackResponse?> DeferAsync(MessageFlags? flags, bool withResponse = false, RestRequestProperties? properties = null, CancellationToken cancellationToken = default) => Context.Interaction.SendResponseAsync(InteractionCallback.DeferredMessage(flags), withResponse, properties, cancellationToken);
+
     public Task<InteractionCallbackResponse?> RespondAsync(InteractionCallbackProperties callback, bool withResponse = false, RestRequestProperties? properties = null, CancellationToken cancellationToken = default) => Context.Interaction.SendResponseAsync(callback, withResponse, properties, cancellationToken);
 
     public Task<RestMessage> GetResponseAsync(RestRequestProperties? properties = null, CancellationToken cancellationToken = default) => Context.Interaction.GetResponseAsync(properties, cancellationToken);

--- a/NetCord.Services/ComponentInteractions/ComponentInteractionModule.cs
+++ b/NetCord.Services/ComponentInteractions/ComponentInteractionModule.cs
@@ -4,6 +4,8 @@ namespace NetCord.Services.ComponentInteractions;
 
 public class ComponentInteractionModule<TContext> : BaseComponentInteractionModule<TContext> where TContext : IComponentInteractionContext
 {
+    public Task<InteractionCallbackResponse?> DeferAsync(bool withResponse = false, RestRequestProperties? properties = null, CancellationToken cancellationToken = default) => Context.Interaction.SendResponseAsync(InteractionCallback.DeferredModifyMessage, withResponse, properties, cancellationToken);
+
     public Task<InteractionCallbackResponse?> RespondAsync(InteractionCallbackProperties callback, bool withResponse = false, RestRequestProperties? properties = null, CancellationToken cancellationToken = default) => Context.Interaction.SendResponseAsync(callback, withResponse, properties, cancellationToken);
 
     public Task<RestMessage> GetResponseAsync(RestRequestProperties? properties = null, CancellationToken cancellationToken = default) => Context.Interaction.GetResponseAsync(properties, cancellationToken);


### PR DESCRIPTION
A small PR that adds a `DeferAsync` helper method to the base `ApplicationCommandModule`/`ComponentInteractionModule` classes.

These methods are intended to ease users (such as myself) that may be migrating from Discord.NET, as well as reduce boilerplate in module implementations.