### PR TITLE
Refactor EnumTypeReader for thread safety and clarity

### DIFF
--- a/NetCord.Services/ApplicationCommands/TypeReaders/EnumTypeReader.cs
+++ b/NetCord.Services/ApplicationCommands/TypeReaders/EnumTypeReader.cs
@@ -11,7 +11,7 @@ public class EnumTypeReader<TContext> : SlashCommandTypeReader<TContext> where T
 
     public unsafe EnumTypeReader()
     {
-        _enumTypeReaderManager = new(&GetKey, (type, parameter, configuration) => new SlashCommandEnumTypeReader<TContext>(type));
+        _enumTypeReaderManager = new(&GetKey, static (type, parameter, configuration) => new SlashCommandEnumTypeReader<TContext>(type));
 
         static Type GetKey(SlashCommandParameter<TContext> parameter) => parameter.NonNullableType;
     }

--- a/NetCord.Services/Commands/TypeReaders/EnumTypeReader.cs
+++ b/NetCord.Services/Commands/TypeReaders/EnumTypeReader.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Collections.Concurrent;
+using System.Reflection;
 
 using NetCord.Services.EnumTypeReaders;
 
@@ -7,26 +8,25 @@ namespace NetCord.Services.Commands.TypeReaders;
 public class EnumTypeReader<TContext> : CommandTypeParser<TContext> where TContext : ICommandContext
 {
     private readonly EnumTypeReaderManager<IEnumTypeReader, CommandParameter<TContext>, CommandParameter<TContext>, CommandServiceConfiguration<TContext>> _enumTypeReaderManager;
-    private readonly Dictionary<Type, bool> _byValueTypes = [];
+    private readonly ConcurrentDictionary<Type, bool> _byValueTypes = [];
 
     public unsafe EnumTypeReader()
     {
-        _enumTypeReaderManager = new(&GetKey, (parameter, _, configuration) =>
-        {
-            var type = parameter.NonNullableElementType;
-            var allowByValueAttributeType = typeof(AllowByValueAttribute);
-
-            if (parameter.Attributes.ContainsKey(allowByValueAttributeType))
-                return new EnumNameOrValueTypeReader(type, configuration.IgnoreCase, configuration.CultureInfo);
-
-            var byValueTypes = _byValueTypes;
-            if (!byValueTypes.TryGetValue(type, out var byValueType))
-                byValueTypes.Add(type, byValueType = type.IsDefined(typeof(AllowByValueAttribute)));
-
-            return byValueType ? new EnumNameOrValueTypeReader(type, configuration.IgnoreCase, configuration.CultureInfo) : new EnumNameTypeReader(type, configuration.IgnoreCase);
-        });
+        _enumTypeReaderManager = new(&GetKey, CreateTypeReader);
 
         static CommandParameter<TContext> GetKey(CommandParameter<TContext> parameter) => parameter;
+    }
+
+    private IEnumTypeReader CreateTypeReader(CommandParameter<TContext> parameter, CommandParameter<TContext> _, CommandServiceConfiguration<TContext> configuration)
+    {
+        var type = parameter.NonNullableElementType;
+
+        if (parameter.Attributes.ContainsKey(typeof(AllowByValueAttribute)))
+            return new EnumNameOrValueTypeReader(type, configuration.IgnoreCase, configuration.CultureInfo);
+
+        var byValueType = _byValueTypes.GetOrAdd(type, static type => type.IsDefined(typeof(AllowByValueAttribute)));
+
+        return byValueType ? new EnumNameOrValueTypeReader(type, configuration.IgnoreCase, configuration.CultureInfo) : new EnumNameTypeReader(type, configuration.IgnoreCase);
     }
 
     public override ValueTask<CommandTypeParserResult> ParseAsync(ReadOnlyMemory<char> input, TContext context, CommandParameter<TContext> parameter, CommandServiceConfiguration<TContext> configuration, IServiceProvider? serviceProvider)

--- a/NetCord.Services/ComponentInteractions/TypeReaders/EnumTypeReader.cs
+++ b/NetCord.Services/ComponentInteractions/TypeReaders/EnumTypeReader.cs
@@ -8,7 +8,7 @@ public class EnumTypeReader<TContext> : ComponentInteractionTypeReader<TContext>
 
     public unsafe EnumTypeReader()
     {
-        _enumTypeReaderManager = new(&GetKey, (type, parameter, configuration) => EnumValueTypeReader.Create(type, configuration.CultureInfo));
+        _enumTypeReaderManager = new(&GetKey, static (type, parameter, configuration) => EnumValueTypeReader.Create(type, configuration.CultureInfo));
 
         static Type GetKey(ComponentInteractionParameter<TContext> parameter) => parameter.NonNullableElementType;
     }


### PR DESCRIPTION
Refactored the `EnumTypeReader` class to improve thread safety, performance, and maintainability. Key changes include:

- Added `static` keyword to lambda expressions to prevent scope capture.
- Replaced `Dictionary` with `ConcurrentDictionary` for thread-safe operations.
- Moved type reader creation logic to a new `CreateTypeReader` method.
- Used `GetOrAdd` for atomic operations on `_byValueTypes`.
- Updated `using` directives to include `System.Collections.Concurrent`.
- Made `GetKey` methods static for consistency and performance.
- Performed general code cleanup and modernization.