### PR TITLE
Add AutoStartStop option to gateway services

### DIFF
--- a/Hosting/NetCord.Hosting/Gateway/GatewayClientHostedService.cs
+++ b/Hosting/NetCord.Hosting/Gateway/GatewayClientHostedService.cs
@@ -10,11 +10,6 @@ internal partial class GatewayClientHostedService(IServiceProvider services) : I
 {
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        var options = services.GetRequiredService<IOptions<GatewayClientOptions>>().Value;
-
-        if (!options.AutoStartStop.GetValueOrDefault(true))
-            return Task.CompletedTask;
-
         var client = services.GetRequiredService<GatewayClient>();
 
         foreach (var handler in services.GetServices<IGatewayHandler>())
@@ -25,7 +20,11 @@ internal partial class GatewayClientHostedService(IServiceProvider services) : I
                 RegisterClassHandler(client, handler);
         }
 
-        return client.StartAsync(cancellationToken: cancellationToken).AsTask();
+        var options = services.GetRequiredService<IOptions<GatewayClientOptions>>().Value;
+
+        return options.AutoStartStop.GetValueOrDefault(true)
+            ? client.StartAsync(cancellationToken: cancellationToken).AsTask()
+            : Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)

--- a/Hosting/NetCord.Hosting/Gateway/GatewayClientHostedService.cs
+++ b/Hosting/NetCord.Hosting/Gateway/GatewayClientHostedService.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 using NetCord.Gateway;
 
@@ -9,6 +10,11 @@ internal partial class GatewayClientHostedService(IServiceProvider services) : I
 {
     public Task StartAsync(CancellationToken cancellationToken)
     {
+        var options = services.GetRequiredService<IOptions<GatewayClientOptions>>().Value;
+
+        if (!options.AutoStartStop.GetValueOrDefault(true))
+            return Task.CompletedTask;
+
         var client = services.GetRequiredService<GatewayClient>();
 
         foreach (var handler in services.GetServices<IGatewayHandler>())
@@ -24,6 +30,11 @@ internal partial class GatewayClientHostedService(IServiceProvider services) : I
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
+        var options = services.GetRequiredService<IOptions<GatewayClientOptions>>().Value;
+
+        if (!options.AutoStartStop.GetValueOrDefault(true))
+            return Task.CompletedTask;
+
         var client = services.GetRequiredService<GatewayClient>();
 
         return client.CloseAsync(cancellationToken: cancellationToken).AsTask();

--- a/Hosting/NetCord.Hosting/Gateway/GatewayClientOptions.cs
+++ b/Hosting/NetCord.Hosting/Gateway/GatewayClientOptions.cs
@@ -23,6 +23,8 @@ public partial class GatewayClientOptions : IDiscordOptions
 
     public string? PublicKey { get; set; }
 
+    public bool? AutoStartStop { get; set; }
+
     /// <inheritdoc cref="GatewayClientConfiguration.WebSocketConnectionProvider" />
     public IWebSocketConnectionProvider? WebSocketConnectionProvider { get; set; }
 

--- a/Hosting/NetCord.Hosting/Gateway/ShardedGatewayClientHostedService.cs
+++ b/Hosting/NetCord.Hosting/Gateway/ShardedGatewayClientHostedService.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 using NetCord.Gateway;
 
@@ -9,6 +10,11 @@ internal partial class ShardedGatewayClientHostedService(IServiceProvider servic
 {
     public Task StartAsync(CancellationToken cancellationToken)
     {
+        var options = services.GetRequiredService<IOptions<ShardedGatewayClientOptions>>().Value;
+
+        if (!options.AutoStartStop.GetValueOrDefault(true))
+            return Task.CompletedTask;
+
         var client = services.GetRequiredService<ShardedGatewayClient>();
 
         foreach (var handler in services.GetServices<IShardedGatewayHandler>())
@@ -24,6 +30,11 @@ internal partial class ShardedGatewayClientHostedService(IServiceProvider servic
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
+        var options = services.GetRequiredService<IOptions<ShardedGatewayClientOptions>>().Value;
+
+        if (!options.AutoStartStop.GetValueOrDefault(true))
+            return Task.CompletedTask;
+
         var client = services.GetRequiredService<ShardedGatewayClient>();
 
         return client.CloseAsync(cancellationToken: cancellationToken).AsTask();

--- a/Hosting/NetCord.Hosting/Gateway/ShardedGatewayClientHostedService.cs
+++ b/Hosting/NetCord.Hosting/Gateway/ShardedGatewayClientHostedService.cs
@@ -10,11 +10,6 @@ internal partial class ShardedGatewayClientHostedService(IServiceProvider servic
 {
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        var options = services.GetRequiredService<IOptions<ShardedGatewayClientOptions>>().Value;
-
-        if (!options.AutoStartStop.GetValueOrDefault(true))
-            return Task.CompletedTask;
-
         var client = services.GetRequiredService<ShardedGatewayClient>();
 
         foreach (var handler in services.GetServices<IShardedGatewayHandler>())
@@ -25,7 +20,11 @@ internal partial class ShardedGatewayClientHostedService(IServiceProvider servic
                 RegisterClassShardedHandler(client, handler);
         }
 
-        return client.StartAsync(cancellationToken: cancellationToken).AsTask();
+        var options = services.GetRequiredService<IOptions<ShardedGatewayClientOptions>>().Value;
+
+        return options.AutoStartStop.GetValueOrDefault(true)
+            ? client.StartAsync(cancellationToken: cancellationToken).AsTask()
+            : Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)

--- a/Hosting/NetCord.Hosting/Gateway/ShardedGatewayClientOptions.cs
+++ b/Hosting/NetCord.Hosting/Gateway/ShardedGatewayClientOptions.cs
@@ -26,6 +26,8 @@ public partial class ShardedGatewayClientOptions : IDiscordOptions
 
     public string? PublicKey { get; set; }
 
+    public bool? AutoStartStop { get; set; }
+
     /// <inheritdoc cref="ShardedGatewayClientConfiguration.WebSocketConnectionProviderFactory" />
     public Func<Shard, IWebSocketConnectionProvider?>? WebSocketConnectionProviderFactory { get; set; }
 

--- a/Tests/NetCord.Test.Hosting/Program.cs
+++ b/Tests/NetCord.Test.Hosting/Program.cs
@@ -48,7 +48,11 @@ builder.Services
     .ConfigureApplicationCommands<ApplicationCommandInteraction, ApplicationCommandContext, AutocompleteInteractionContext>(o => o.DefaultParameterDescriptionFormat = "AA")
     .ConfigureApplicationCommands(o => o.DefaultParameterDescriptionFormat = "XD")
     .ConfigureApplicationCommands(o => o.AutoRegisterCommands = true)
-    .AddDiscordGateway(o => o.Intents = GatewayIntents.All)
+    .AddDiscordGateway(o =>
+    {
+        o.Intents = GatewayIntents.All;
+        o.AutoStartStop = true;
+    })
     .AddApplicationCommands(options =>
     {
         options.ResultHandler = new CustomApplicationCommandResultHandler();


### PR DESCRIPTION
Introduced an `AutoStartStop` option in `GatewayClientOptions` and `ShardedGatewayClientOptions` to control automatic start and stop behavior of gateway clients. Updated `StartAsync` and `StopAsync` methods in `GatewayClientHostedService` and `ShardedGatewayClientHostedService` to respect this option.