### PR TITLE
Refactor party size to use long instead of int

### DIFF
--- a/NetCord/Gateway/JsonModels/JsonParty.cs
+++ b/NetCord/Gateway/JsonModels/JsonParty.cs
@@ -8,5 +8,5 @@ public class JsonParty
     public string? Id { get; set; }
 
     [JsonPropertyName("size")]
-    public int[]? Size { get; set; }
+    public long[]? Size { get; set; }
 }

--- a/NetCord/Gateway/Party.cs
+++ b/NetCord/Gateway/Party.cs
@@ -7,19 +7,13 @@ public class Party : IJsonModel<JsonModels.JsonParty>
 
     public string? Id => _jsonModel.Id;
 
-    public int? CurrentSize { get; }
-
-    public int? MaxSize { get; }
+    public PartySize? Size { get; }
 
     public Party(JsonModels.JsonParty jsonModel)
     {
         _jsonModel = jsonModel;
 
-        var size = jsonModel.Size;
-        if (size is not null)
-        {
-            CurrentSize = size[0];
-            MaxSize = size[1];
-        }
+        if (jsonModel.Size is { } size)
+            Size = new(size);
     }
 }

--- a/NetCord/Gateway/PartySize.cs
+++ b/NetCord/Gateway/PartySize.cs
@@ -1,0 +1,10 @@
+﻿namespace NetCord.Gateway;
+
+public class PartySize(long[] jsonModel) : IJsonModel<long[]>
+{
+    long[] IJsonModel<long[]>.JsonModel => jsonModel;
+
+    public long CurrentSize => jsonModel[0];
+
+    public long MaxSize => jsonModel[1];
+}

--- a/NetCord/Gateway/PartySizeProperties.cs
+++ b/NetCord/Gateway/PartySizeProperties.cs
@@ -5,11 +5,11 @@ namespace NetCord.Gateway;
 
 [JsonConverter(typeof(PartySizePropertiesConverter))]
 [GenerateMethodsForProperties]
-public partial class PartySizeProperties(int currentSize, int maxSize)
+public partial class PartySizeProperties(long currentSize, long maxSize)
 {
-    public int CurrentSize { get; set; } = currentSize;
+    public long CurrentSize { get; set; } = currentSize;
 
-    public int MaxSize { get; set; } = maxSize;
+    public long MaxSize { get; set; } = maxSize;
 
     public class PartySizePropertiesConverter : JsonConverter<PartySizeProperties>
     {


### PR DESCRIPTION
Updated `JsonParty.Size` to `long[]?` to support larger values. Replaced `CurrentSize` and `MaxSize` in `Party` with `PartySize`. Introduced `PartySize` class for better encapsulation. Updated `PartySizeProperties` to use `long` for size properties.