### PR TITLE
Refactor to use environment variable for PR number

### DIFF
--- a/.github/workflows/cleanup-documentation-preview.yml
+++ b/.github/workflows/cleanup-documentation-preview.yml
@@ -20,4 +20,7 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           port: ${{ secrets.SSH_PORT }}
           key: ${{ secrets.SSH_KEY }}
-          script: rm -rf ~/NetCord/preview/html/${{ github.event.pull_request.number }}
+          script: rm -rf ~/NetCord/preview/html/$PULL_REQUEST_NUMBER
+          envs: PULL_REQUEST_NUMBER
+        env:
+          PULL_REQUEST_NUMBER: "${{ github.event.pull_request.number }}"


### PR DESCRIPTION
Replaced direct use of `${{ github.event.pull_request.number }}` with the `PULL_REQUEST_NUMBER` environment variable for improved readability and reusability. Added `envs` and `env` sections to define and declare the `PULL_REQUEST_NUMBER` variable, ensuring it is accessible during job execution. This change simplifies debugging and enhances maintainability.