### PR TITLE
Increase socket discovery timeout to 5 seconds

### DIFF
--- a/NetCord/Gateway/Voice/VoiceClient.cs
+++ b/NetCord/Gateway/Voice/VoiceClient.cs
@@ -111,7 +111,7 @@ public sealed partial class VoiceClient : WebSocketClient
         _udpConnectionProvider = configuration.UdpConnectionProvider ?? UdpConnectionProvider.Instance;
         _encryptionProvider = configuration.EncryptionProvider ?? VoiceEncryptionProvider.Instance;
         _receiveHandler = configuration.ReceiveHandler ?? NullVoiceReceiveHandler.Instance;
-        _externalSocketAddressDiscoveryTimeout = configuration.ExternalSocketAddressDiscoveryTimeout.GetValueOrDefault(new(500 * TimeSpan.TicksPerMillisecond));
+        _externalSocketAddressDiscoveryTimeout = configuration.ExternalSocketAddressDiscoveryTimeout.GetValueOrDefault(new(5 * TimeSpan.TicksPerSecond));
     }
 
     private protected override ValueTask SendIdentifyAsync(ConnectionState connectionState, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Updated the default value for `_externalSocketAddressDiscoveryTimeout` in the `VoiceClient` class from 500 milliseconds to 5 seconds. This change improves reliability in slower network environments by allowing more time for external socket address discovery.