### PR TITLE
Refactor section components to use interface type

### DIFF
--- a/NetCord/Rest/ComponentProperties/ComponentSectionProperties.cs
+++ b/NetCord/Rest/ComponentProperties/ComponentSectionProperties.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 namespace NetCord.Rest;
 
 [GenerateMethodsForProperties]
-public partial class ComponentSectionProperties(IComponentSectionAccessoryComponentProperties accessory, IEnumerable<TextDisplayProperties> components) : IMessageComponentProperties, IComponentContainerComponentProperties, IComponentSectionProperties, IEnumerable<TextDisplayProperties>
+public partial class ComponentSectionProperties(IComponentSectionAccessoryComponentProperties accessory, IEnumerable<IComponentSectionComponentProperties> components) : IMessageComponentProperties, IComponentContainerComponentProperties, IComponentSectionProperties, IEnumerable<IComponentSectionComponentProperties>
 {
     public ComponentSectionProperties(IComponentSectionAccessoryComponentProperties accessory) : this(accessory, [])
     {
@@ -16,12 +16,12 @@ public partial class ComponentSectionProperties(IComponentSectionAccessoryCompon
 
     public ComponentType ComponentType => ComponentType.Section;
 
-    public IEnumerable<TextDisplayProperties> Components { get; set; } = components;
+    public IEnumerable<IComponentSectionComponentProperties> Components { get; set; } = components;
 
     public IComponentSectionAccessoryComponentProperties Accessory { get; set; } = accessory;
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void Add(TextDisplayProperties component) => AddComponents(component);
+    public void Add(IComponentSectionComponentProperties component) => AddComponents(component);
 
     private void WriteTo(Utf8JsonWriter writer)
     {
@@ -38,14 +38,14 @@ public partial class ComponentSectionProperties(IComponentSectionAccessoryCompon
         WriteTo(writer);
     }
 
-    IEnumerator<TextDisplayProperties> IEnumerable<TextDisplayProperties>.GetEnumerator() => Components.GetEnumerator();
+    IEnumerator<IComponentSectionComponentProperties> IEnumerable<IComponentSectionComponentProperties>.GetEnumerator() => Components.GetEnumerator();
     IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)Components).GetEnumerator();
 }
 
 internal interface IComponentSectionProperties : IComponentProperties
 {
     [JsonPropertyName("components")]
-    public IEnumerable<TextDisplayProperties> Components { get; }
+    public IEnumerable<IComponentSectionComponentProperties> Components { get; }
 
     [JsonPropertyName("accessory")]
     public IComponentSectionAccessoryComponentProperties Accessory { get; }

--- a/NetCord/Rest/ComponentProperties/TextDisplayProperties.cs
+++ b/NetCord/Rest/ComponentProperties/TextDisplayProperties.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 namespace NetCord.Rest;
 
 [GenerateMethodsForProperties]
-public partial class TextDisplayProperties(string content) : IMessageComponentProperties, IModalComponentProperties, IComponentContainerComponentProperties
+public partial class TextDisplayProperties(string content) : IMessageComponentProperties, IModalComponentProperties, IComponentContainerComponentProperties, IComponentSectionComponentProperties
 {
     /// <summary>
     /// Unique identifier for the component. Auto populated through increment if not provided.
@@ -35,6 +35,11 @@ public partial class TextDisplayProperties(string content) : IMessageComponentPr
     }
 
     void IJsonSerializable<IComponentContainerComponentProperties>.WriteTo(Utf8JsonWriter writer)
+    {
+        WriteTo(writer);
+    }
+
+    void IJsonSerializable<IComponentSectionComponentProperties>.WriteTo(Utf8JsonWriter writer)
     {
         WriteTo(writer);
     }


### PR DESCRIPTION
ComponentSectionProperties now uses IComponentSectionComponentProperties instead of TextDisplayProperties, allowing sections to contain any compatible component type. Updated constructors, properties, methods, and interfaces accordingly. TextDisplayProperties now implements the new interface and supports proper serialization. This generalizes and extends the section component model.