### PR TITLE
Add banner, avatar, and bio fields to user options

### DIFF
--- a/NetCord/Rest/CurrentGuildUserOptions.cs
+++ b/NetCord/Rest/CurrentGuildUserOptions.cs
@@ -15,4 +15,25 @@ public partial class CurrentGuildUserOptions
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("nick")]
     public string? Nickname { get; set; }
+
+    /// <summary>
+    /// New banner image.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("banner")]
+    public ImageProperties? Banner { get; set; }
+
+    /// <summary>
+    /// New avatar image.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("avatar")]
+    public ImageProperties? Avatar { get; set; }
+
+    /// <summary>
+    /// New bio, empty to remove bio.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("bio")]
+    public string? Bio { get; set; }
 }


### PR DESCRIPTION
Added Banner, Avatar, and Bio properties to the CurrentGuildUserOptions class, allowing updates to user banner image, avatar image, and bio. Properties include appropriate JSON serialization attributes for correct API behavior.