### PR TITLE
Refactor role comparison logic into RolePosition struct

### DIFF
--- a/Documentation/guides/services/CustomModuleBasesAndContexts/CustomModuleBases/CustomCommandModule.cs
+++ b/Documentation/guides/services/CustomModuleBasesAndContexts/CustomModuleBases/CustomCommandModule.cs
@@ -8,7 +8,7 @@ public abstract class CustomCommandModule : CommandModule<CommandContext>
     public Color GetUserColor(GuildUser user)
     {
         return (user.GetRoles(Context.Guild!)
-                    .OrderDescending()
+                    .OrderByDescending(r => r.Position)
                     .FirstOrDefault(r => r.Color != default)?.Color).GetValueOrDefault();
     }
 }

--- a/NetCord/Rest/RestGuild.cs
+++ b/NetCord/Rest/RestGuild.cs
@@ -58,13 +58,13 @@ public partial class RestGuild : ClientEntity, IJsonModel<JsonGuild>, IComparer<
         if (x.RoleIds.Count is 0)
             return -y.RoleIds.Count;
 
-        var xHighestRole = x.GetRoles(this).Max()!;
+        var xHighestPosition = x.GetRoles(this).Max(r => r.Position);
 
         int result = 1;
 
         foreach (var role in y.GetRoles(this))
         {
-            var comparisonResult = xHighestRole.CompareTo(role);
+            var comparisonResult = xHighestPosition.CompareTo(role.Position);
 
             if (comparisonResult < 0)
                 return -1;

--- a/NetCord/Role.cs
+++ b/NetCord/Role.cs
@@ -56,10 +56,16 @@ public partial class Role : ClientEntity, IJsonModel<JsonRole>
     public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null) => Mention.TryFormatRole(destination, out charsWritten, Id);
 }
 
-public readonly struct RolePosition(int position, ulong roleId) : IComparable<RolePosition>, IEquatable<RolePosition>
+public readonly struct RolePosition : IComparable<RolePosition>, IEquatable<RolePosition>
 {
-    private readonly int _position = position;
-    private readonly ulong _roleId = roleId;
+    private readonly int _position;
+    private readonly ulong _roleId;
+
+    internal RolePosition(int position, ulong roleId)
+    {
+        _position = position;
+        _roleId = roleId;
+    }
 
     public override int GetHashCode()
     {

--- a/NetCord/Role.cs
+++ b/NetCord/Role.cs
@@ -1,9 +1,11 @@
-﻿using NetCord.JsonModels;
+﻿using System.Diagnostics.CodeAnalysis;
+
+using NetCord.JsonModels;
 using NetCord.Rest;
 
 namespace NetCord;
 
-public partial class Role : ClientEntity, IJsonModel<JsonRole>, IComparable<Role>
+public partial class Role : ClientEntity, IJsonModel<JsonRole>
 {
     JsonRole IJsonModel<JsonRole>.JsonModel => _jsonModel;
     private readonly JsonRole _jsonModel;
@@ -20,7 +22,9 @@ public partial class Role : ClientEntity, IJsonModel<JsonRole>, IComparable<Role
 
     public string? UnicodeEmoji => _jsonModel.UnicodeEmoji;
 
-    public int Position => _jsonModel.Position;
+    public int RawPosition => _jsonModel.Position;
+
+    public RolePosition Position => new(RawPosition, Id);
 
     public Permissions Permissions => _jsonModel.Permissions;
 
@@ -50,42 +54,62 @@ public partial class Role : ClientEntity, IJsonModel<JsonRole>, IComparable<Role
     public override string ToString() => $"<@&{Id}>";
 
     public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null) => Mention.TryFormatRole(destination, out charsWritten, Id);
+}
 
-    public int CompareTo(Role? other)
+public readonly struct RolePosition(int position, ulong roleId) : IComparable<RolePosition>, IEquatable<RolePosition>
+{
+    private readonly int _position = position;
+    private readonly ulong _roleId = roleId;
+
+    public override int GetHashCode()
     {
-        if (other is null)
-            return 1;
-
-        var positionCompare = Position.CompareTo(other.Position);
-        return positionCompare is 0 ? other.Id.CompareTo(Id) : positionCompare;
+        return HashCode.Combine(_position, _roleId);
     }
 
-    public static bool operator >(Role left, Role right)
+    public override bool Equals([NotNullWhen(true)] object? obj)
     {
-        var leftPosition = left.Position;
-        var rightPosition = right.Position;
-        return leftPosition > rightPosition || (leftPosition == rightPosition && left.Id < right.Id);
+        return obj is RolePosition other && Equals(other);
     }
 
-    public static bool operator <(Role left, Role right)
+    public bool Equals(RolePosition other)
     {
-        var leftPosition = left.Position;
-        var rightPosition = right.Position;
-        return leftPosition < rightPosition || (leftPosition == rightPosition && left.Id > right.Id);
+        return _position == other._position && _roleId == other._roleId;
     }
 
-    public static bool operator >=(Role left, Role right)
+    public int CompareTo(RolePosition other)
     {
-        var leftPosition = left.Position;
-        var rightPosition = right.Position;
-        return leftPosition > rightPosition || (leftPosition == rightPosition && left.Id <= right.Id);
+        var positionCompare = _position.CompareTo(other._position);
+        return positionCompare is 0 ? other._roleId.CompareTo(_roleId) : positionCompare;
     }
 
-    public static bool operator <=(Role left, Role right)
+    public static bool operator ==(RolePosition left, RolePosition right)
     {
-        var leftPosition = left.Position;
-        var rightPosition = right.Position;
-        return leftPosition < rightPosition || (leftPosition == rightPosition && left.Id >= right.Id);
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(RolePosition left, RolePosition right)
+    {
+        return !left.Equals(right);
+    }
+
+    public static bool operator >(RolePosition left, RolePosition right)
+    {
+        return left._position > right._position || (left._position == right._position && left._roleId < right._roleId);
+    }
+
+    public static bool operator <(RolePosition left, RolePosition right)
+    {
+        return left._position < right._position || (left._position == right._position && left._roleId > right._roleId);
+    }
+
+    public static bool operator >=(RolePosition left, RolePosition right)
+    {
+        return left._position > right._position || (left._position == right._position && left._roleId <= right._roleId);
+    }
+
+    public static bool operator <=(RolePosition left, RolePosition right)
+    {
+        return left._position < right._position || (left._position == right._position && left._roleId >= right._roleId);
     }
 }
 

--- a/Tests/NetCord.Test/Commands/NormalCommands.cs
+++ b/Tests/NetCord.Test/Commands/NormalCommands.cs
@@ -55,7 +55,7 @@ public class NormalCommands : CommandModule<CommandContext>
 
     public static MenuProperties CreateRolesMenu(IEnumerable<Role> guildRoles, IEnumerable<ulong> defaultValues)
     {
-        var roles = guildRoles.Where(r => !r.Managed).OrderDescending().SkipLast(1);
+        var roles = guildRoles.Where(r => !r.Managed).OrderByDescending(r => r.Position).SkipLast(1);
         List<StringMenuSelectOptionProperties> options = [];
         foreach (var role in roles)
             options.Add(new(role.Name, role.Id.ToString()!) { Default = defaultValues.Contains(role.Id) });

--- a/Tests/RoleTest/RoleComparison.cs
+++ b/Tests/RoleTest/RoleComparison.cs
@@ -18,44 +18,56 @@ public sealed class RoleComparison
     {
         if (role1Greater)
         {
-            Assert.IsGreaterThan(0, role1.CompareTo(role2));
-            Assert.IsLessThan(0, role2.CompareTo(role1));
+            Assert.IsGreaterThan(0, role1.Position.CompareTo(role2.Position));
+            Assert.IsLessThan(0, role2.Position.CompareTo(role1.Position));
         }
         else
         {
-            Assert.IsLessThan(0, role1.CompareTo(role2));
-            Assert.IsGreaterThan(0, role2.CompareTo(role1));
+            Assert.IsLessThan(0, role1.Position.CompareTo(role2.Position));
+            Assert.IsGreaterThan(0, role2.Position.CompareTo(role1.Position));
         }
 
-        Assert.AreEqual(role1Greater, role1 > role2);
-        Assert.AreEqual(!role1Greater, role2 > role1);
+        Assert.IsFalse(role1.Position == role2.Position);
+        Assert.IsFalse(role2.Position == role1.Position);
 
-        Assert.AreEqual(role1Greater, role1 >= role2);
-        Assert.AreEqual(!role1Greater, role2 >= role1);
+        Assert.IsTrue(role1.Position != role2.Position);
+        Assert.IsTrue(role2.Position != role1.Position);
 
-        Assert.AreEqual(!role1Greater, role1 < role2);
-        Assert.AreEqual(role1Greater, role2 < role1);
+        Assert.AreEqual(role1Greater, role1.Position > role2.Position);
+        Assert.AreEqual(!role1Greater, role2.Position > role1.Position);
 
-        Assert.AreEqual(!role1Greater, role1 <= role2);
-        Assert.AreEqual(role1Greater, role2 <= role1);
+        Assert.AreEqual(role1Greater, role1.Position >= role2.Position);
+        Assert.AreEqual(!role1Greater, role2.Position >= role1.Position);
+
+        Assert.AreEqual(!role1Greater, role1.Position < role2.Position);
+        Assert.AreEqual(role1Greater, role2.Position < role1.Position);
+
+        Assert.AreEqual(!role1Greater, role1.Position <= role2.Position);
+        Assert.AreEqual(role1Greater, role2.Position <= role1.Position);
     }
 
     private static void Equal(Role role1, Role role2)
     {
-        Assert.AreEqual(0, role1.CompareTo(role2));
-        Assert.AreEqual(0, role2.CompareTo(role1));
+        Assert.AreEqual(0, role1.Position.CompareTo(role2.Position));
+        Assert.AreEqual(0, role2.Position.CompareTo(role1.Position));
 
-        Assert.IsFalse(role1 > role2);
-        Assert.IsFalse(role2 > role1);
+        Assert.IsTrue(role1.Position == role2.Position);
+        Assert.IsTrue(role2.Position == role1.Position);
 
-        Assert.IsTrue(role1 >= role2);
-        Assert.IsTrue(role2 >= role1);
+        Assert.IsFalse(role1.Position != role2.Position);
+        Assert.IsFalse(role2.Position != role1.Position);
 
-        Assert.IsFalse(role1 < role2);
-        Assert.IsFalse(role2 < role1);
+        Assert.IsFalse(role1.Position > role2.Position);
+        Assert.IsFalse(role2.Position > role1.Position);
 
-        Assert.IsTrue(role1 <= role2);
-        Assert.IsTrue(role2 <= role1);
+        Assert.IsTrue(role1.Position >= role2.Position);
+        Assert.IsTrue(role2.Position >= role1.Position);
+
+        Assert.IsFalse(role1.Position < role2.Position);
+        Assert.IsFalse(role2.Position < role1.Position);
+
+        Assert.IsTrue(role1.Position <= role2.Position);
+        Assert.IsTrue(role2.Position <= role1.Position);
     }
 
     [TestMethod]


### PR DESCRIPTION
Move all role position comparison logic from Role to a new RolePosition struct, including comparison operators and methods. Update Role to expose a Position property of type RolePosition and remove IComparable<Role> implementation. Refactor all usages and tests to use RolePosition for ordering and equality checks. Improve code clarity and maintainability by centralizing comparison logic.