### PR TITLE
Add leaveOpen option to streams

### DIFF
--- a/NetCord/Gateway/Voice/Streams/OpusDecodeStream.cs
+++ b/NetCord/Gateway/Voice/Streams/OpusDecodeStream.cs
@@ -18,7 +18,8 @@ public sealed class OpusDecodeStream : RewritingStream
     /// <param name="next">The stream that this stream is writing to.</param>
     /// <param name="format">The PCM format to decode to.</param>
     /// <param name="channels">Number of channels to decode.</param>
-    public OpusDecodeStream(Stream next, PcmFormat format, VoiceChannels channels) : base(next)
+    /// <param name="leaveOpen">Whether to leave the next stream open when this stream is disposed.</param>
+    public OpusDecodeStream(Stream next, PcmFormat format, VoiceChannels channels, bool leaveOpen = false) : base(next, leaveOpen)
     {
         _decoder = new(channels);
         _decode = format switch

--- a/NetCord/Gateway/Voice/Streams/OpusEncodeStream.cs
+++ b/NetCord/Gateway/Voice/Streams/OpusEncodeStream.cs
@@ -11,7 +11,8 @@ namespace NetCord.Gateway.Voice;
 /// <param name="channels">Number of channels in input signal.</param>
 /// <param name="application">Opus coding mode.</param>
 /// <param name="configuration">The configuration of the stream.</param>
-public sealed class OpusEncodeStream(Stream next, PcmFormat format, VoiceChannels channels, OpusApplication application, OpusEncodeStreamConfiguration? configuration = null) : RewritingStream(CreateNextStream(next, format, channels, application, configuration))
+/// <param name="leaveOpen">Whether to leave the next stream open when this stream is disposed.</param>
+public sealed class OpusEncodeStream(Stream next, PcmFormat format, VoiceChannels channels, OpusApplication application, OpusEncodeStreamConfiguration? configuration = null, bool leaveOpen = false) : RewritingStream(CreateNextStream(next, format, channels, application, configuration), leaveOpen)
 {
     private static Stream CreateNextStream(Stream next, PcmFormat format, VoiceChannels channels, OpusApplication application, OpusEncodeStreamConfiguration? configuration)
     {

--- a/NetCord/Gateway/Voice/Streams/OpusEncodeStream.cs
+++ b/NetCord/Gateway/Voice/Streams/OpusEncodeStream.cs
@@ -12,14 +12,14 @@ namespace NetCord.Gateway.Voice;
 /// <param name="application">Opus coding mode.</param>
 /// <param name="configuration">The configuration of the stream.</param>
 /// <param name="leaveOpen">Whether to leave the next stream open when this stream is disposed.</param>
-public sealed class OpusEncodeStream(Stream next, PcmFormat format, VoiceChannels channels, OpusApplication application, OpusEncodeStreamConfiguration? configuration = null, bool leaveOpen = false) : RewritingStream(CreateNextStream(next, format, channels, application, configuration), leaveOpen)
+public sealed class OpusEncodeStream(Stream next, PcmFormat format, VoiceChannels channels, OpusApplication application, OpusEncodeStreamConfiguration? configuration = null, bool leaveOpen = false) : RewritingStream(CreateNextStream(next, format, channels, application, configuration, leaveOpen))
 {
-    private static Stream CreateNextStream(Stream next, PcmFormat format, VoiceChannels channels, OpusApplication application, OpusEncodeStreamConfiguration? configuration)
+    private static Stream CreateNextStream(Stream next, PcmFormat format, VoiceChannels channels, OpusApplication application, OpusEncodeStreamConfiguration? configuration, bool leaveOpen)
     {
         var frameDuration = configuration?.FrameDuration ?? Opus.DefaultFrameDuration;
         var segment = configuration?.Segment ?? true;
 
-        OpusEncodeStreamInternal encodeStream = new(next, frameDuration, format, channels, application);
+        OpusEncodeStreamInternal encodeStream = new(next, frameDuration, format, channels, application, leaveOpen);
         return segment ? new SegmentingStream(encodeStream, frameDuration, format, channels)
                        : encodeStream;
     }
@@ -143,7 +143,7 @@ public sealed class OpusEncodeStream(Stream next, PcmFormat format, VoiceChannel
         private readonly int _opusBufferSize;
         private readonly int _pcmBufferSize;
 
-        public OpusEncodeStreamInternal(Stream next, float frameDuration, PcmFormat format, VoiceChannels channels, OpusApplication application) : base(next)
+        public OpusEncodeStreamInternal(Stream next, float frameDuration, PcmFormat format, VoiceChannels channels, OpusApplication application, bool leaveOpen) : base(next, leaveOpen)
         {
             _encoder = new(channels, application);
             _encode = format switch

--- a/NetCord/Gateway/Voice/Streams/RewritingStream.cs
+++ b/NetCord/Gateway/Voice/Streams/RewritingStream.cs
@@ -4,9 +4,11 @@
 /// 
 /// </summary>
 /// <param name="next">The stream that this stream is writing to.</param>
-public abstract class RewritingStream(Stream next) : Stream
+/// <param name="leaveOpen">Whether to leave the next stream open when this stream is disposed.</param>
+public abstract class RewritingStream(Stream next, bool leaveOpen = false) : Stream
 {
     private protected readonly Stream _next = next;
+    private readonly bool _leaveOpen = leaveOpen;
 
     public override bool CanRead => false;
     public override bool CanSeek => false;
@@ -40,7 +42,7 @@ public abstract class RewritingStream(Stream next) : Stream
 
     protected override void Dispose(bool disposing)
     {
-        if (disposing)
+        if (disposing && !_leaveOpen)
             _next.Dispose();
     }
 }


### PR DESCRIPTION
Added a leaveOpen parameter to RewritingStream, OpusDecodeStream, and OpusEncodeStream constructors. Updated Dispose logic to conditionally close the underlying stream based on leaveOpen, allowing callers to manage stream lifetimes more flexibly.