### PR TITLE
Add GuidTypeReader for component interaction parameters

### DIFF
--- a/NetCord.Services/ComponentInteractions/ComponentInteractionServiceConfiguration.cs
+++ b/NetCord.Services/ComponentInteractions/ComponentInteractionServiceConfiguration.cs
@@ -49,7 +49,7 @@ public record ComponentInteractionServiceConfiguration<TContext> where TContext 
         { typeof(UserId), new TypeReaders.UserIdTypeReader<TContext>() },
         { typeof(Timestamp), new TypeReaders.TimestampTypeReader<TContext>() },
         { typeof(CodeBlock), new TypeReaders.CodeBlockTypeReader<TContext>() },
-        { typeof(Guid, new TypeReaders.GuidTypeReader<TContext>() }
+        { typeof(Guid), new TypeReaders.GuidTypeReader<TContext>() }
     #endregion
     }.ToImmutableDictionary();
 

--- a/NetCord.Services/ComponentInteractions/ComponentInteractionServiceConfiguration.cs
+++ b/NetCord.Services/ComponentInteractions/ComponentInteractionServiceConfiguration.cs
@@ -48,7 +48,8 @@ public record ComponentInteractionServiceConfiguration<TContext> where TContext 
         { typeof(GuildUser), new TypeReaders.GuildUserTypeReader<TContext>() },
         { typeof(UserId), new TypeReaders.UserIdTypeReader<TContext>() },
         { typeof(Timestamp), new TypeReaders.TimestampTypeReader<TContext>() },
-        { typeof(CodeBlock), new TypeReaders.CodeBlockTypeReader<TContext>() }
+        { typeof(CodeBlock), new TypeReaders.CodeBlockTypeReader<TContext>() },
+        { typeof(Guid, new TypeReaders.GuidTypeReader<TContext>() }
     #endregion
     }.ToImmutableDictionary();
 

--- a/NetCord.Services/ComponentInteractions/TypeReaders/GuidTypeReader.cs
+++ b/NetCord.Services/ComponentInteractions/TypeReaders/GuidTypeReader.cs
@@ -1,0 +1,6 @@
+﻿namespace NetCord.Services.ComponentInteractions.TypeReaders;
+
+public class GuidTypeReader<TContext> : ComponentInteractionTypeReader<TContext> where TContext : IComponentInteractionContext
+{
+    public override ValueTask<ComponentInteractionTypeReaderResult> ReadAsync(ReadOnlyMemory<char> input, TContext context, ComponentInteractionParameter<TContext> parameter, ComponentInteractionServiceConfiguration<TContext> configuration, IServiceProvider? serviceProvider) => new (Guid.TryParse(input.ToString(), out var value) ? ComponentInteractionTypeReaderResult.Success(value) : ComponentInteractionTypeReaderResult.ParseFail(parameter.Name));
+}

--- a/NetCord.Services/ComponentInteractions/TypeReaders/GuidTypeReader.cs
+++ b/NetCord.Services/ComponentInteractions/TypeReaders/GuidTypeReader.cs
@@ -2,5 +2,5 @@
 
 public class GuidTypeReader<TContext> : ComponentInteractionTypeReader<TContext> where TContext : IComponentInteractionContext
 {
-    public override ValueTask<ComponentInteractionTypeReaderResult> ReadAsync(ReadOnlyMemory<char> input, TContext context, ComponentInteractionParameter<TContext> parameter, ComponentInteractionServiceConfiguration<TContext> configuration, IServiceProvider? serviceProvider) => new (Guid.TryParse(input.ToString(), out var value) ? ComponentInteractionTypeReaderResult.Success(value) : ComponentInteractionTypeReaderResult.ParseFail(parameter.Name));
+    public override ValueTask<ComponentInteractionTypeReaderResult> ReadAsync(ReadOnlyMemory<char> input, TContext context, ComponentInteractionParameter<TContext> parameter, ComponentInteractionServiceConfiguration<TContext> configuration, IServiceProvider? serviceProvider) => new(Guid.TryParse(input.Span, out var value) ? ComponentInteractionTypeReaderResult.Success(value) : ComponentInteractionTypeReaderResult.ParseFail(parameter.Name));
 }


### PR DESCRIPTION
Guids are often used for ID and such, this simplifies passing it to a component without having to parse it ourselves.