### PR TITLE
Fix missing HTTP content in metadata update request

### DIFF
--- a/NetCord/Rest/RestClient.ApplicationRoleConnectionMetadata.cs
+++ b/NetCord/Rest/RestClient.ApplicationRoleConnectionMetadata.cs
@@ -10,6 +10,6 @@ public partial class RestClient
     public async Task<IReadOnlyList<ApplicationRoleConnectionMetadata>> UpdateApplicationRoleConnectionMetadataRecordsAsync(ulong applicationId, IEnumerable<ApplicationRoleConnectionMetadataProperties> applicationRoleConnectionMetadataProperties, RestRequestProperties? properties = null, CancellationToken cancellationToken = default)
     {
         using (HttpContent content = new JsonContent<IEnumerable<ApplicationRoleConnectionMetadataProperties>>(applicationRoleConnectionMetadataProperties, Serialization.Default.IEnumerableApplicationRoleConnectionMetadataProperties))
-            return (await (await SendRequestAsync(HttpMethod.Put, $"/applications/{applicationId}/role-connections/metadata", null, null, properties, cancellationToken: cancellationToken).ConfigureAwait(false)).ToObjectAsync(Serialization.Default.IEnumerableJsonApplicationRoleConnectionMetadata).ConfigureAwait(false)).Select(m => new ApplicationRoleConnectionMetadata(m)).ToArray();
+            return (await (await SendRequestAsync(HttpMethod.Put, content, $"/applications/{applicationId}/role-connections/metadata", null, null, properties, cancellationToken: cancellationToken).ConfigureAwait(false)).ToObjectAsync(Serialization.Default.IEnumerableJsonApplicationRoleConnectionMetadata).ConfigureAwait(false)).Select(m => new ApplicationRoleConnectionMetadata(m)).ToArray();
     }
 }


### PR DESCRIPTION
Previously, the serialized metadata properties were not included in the PUT request body when updating application role connection metadata records. This change ensures the HTTP content is correctly passed to SendRequestAsync, allowing the API to receive the intended data.