### PR TITLE
refactor: remove `ActiveDeveloper` user flag

### DIFF
--- a/NetCord/UserFlags.cs
+++ b/NetCord/UserFlags.cs
@@ -121,11 +121,6 @@ public enum UserFlags : ulong
     DisablePremium = 1uL << 21,
 
     /// <summary>
-    /// User has the 'Active Developer' badge. See <see href="https://support-dev.discord.com/hc/articles/10113997751447"/>.
-    /// </summary>
-    ActiveDeveloper = 1uL << 22,
-
-    /// <summary>
     /// Undocumented and private. User's account has a high global rate limit.
     /// </summary>
     HighGlobalRateLimit = 1uL << 33,


### PR DESCRIPTION
The Active Developer Badge has been removed and is no longer obtainable.

References:
- https://support-dev.discord.com/hc/en-us/articles/10113997751447-Active-Developer-Badge
- https://github.com/discord/discord-api-docs/pull/8249