### PR TITLE
Expose message_reference.type on MessageReference

### DIFF
--- a/NetCord/JsonModels/JsonMessageReference.cs
+++ b/NetCord/JsonModels/JsonMessageReference.cs
@@ -4,6 +4,9 @@ namespace NetCord.JsonModels;
 
 public class JsonMessageReference
 {
+    [JsonPropertyName("type")]
+    public MessageReferenceType? Type { get; set; }
+    
     [JsonPropertyName("message_id")]
     public ulong? MessageId { get; set; }
 

--- a/NetCord/JsonModels/JsonMessageReference.cs
+++ b/NetCord/JsonModels/JsonMessageReference.cs
@@ -6,6 +6,7 @@ public class JsonMessageReference
 {
     [JsonPropertyName("type")]
     public MessageReferenceType? Type { get; set; }
+
     [JsonPropertyName("message_id")]
     public ulong? MessageId { get; set; }
 

--- a/NetCord/JsonModels/JsonMessageReference.cs
+++ b/NetCord/JsonModels/JsonMessageReference.cs
@@ -6,7 +6,6 @@ public class JsonMessageReference
 {
     [JsonPropertyName("type")]
     public MessageReferenceType? Type { get; set; }
-    
     [JsonPropertyName("message_id")]
     public ulong? MessageId { get; set; }
 

--- a/NetCord/MessageReference.cs
+++ b/NetCord/MessageReference.cs
@@ -4,6 +4,7 @@ public class MessageReference(JsonModels.JsonMessageReference jsonModel) : IJson
 {
     JsonModels.JsonMessageReference IJsonModel<JsonModels.JsonMessageReference>.JsonModel => jsonModel;
 
+    public MessageReferenceType? Type => jsonModel.Type;
     public ulong MessageId => jsonModel.MessageId.GetValueOrDefault();
     public ulong ChannelId => jsonModel.ChannelId.GetValueOrDefault();
     public ulong? GuildId => jsonModel.GuildId;

--- a/NetCord/MessageReference.cs
+++ b/NetCord/MessageReference.cs
@@ -4,7 +4,7 @@ public class MessageReference(JsonModels.JsonMessageReference jsonModel) : IJson
 {
     JsonModels.JsonMessageReference IJsonModel<JsonModels.JsonMessageReference>.JsonModel => jsonModel;
 
-    public MessageReferenceType? Type => jsonModel.Type;
+    public MessageReferenceType Type => jsonModel.Type.GetValueOrDefault();
     public ulong MessageId => jsonModel.MessageId.GetValueOrDefault();
     public ulong ChannelId => jsonModel.ChannelId.GetValueOrDefault();
     public ulong? GuildId => jsonModel.GuildId;


### PR DESCRIPTION
Adds support for the type field on message_reference objects returned in message payloads, including MESSAGE_CREATE gateway events and retrieved messages.

Discord documents message_reference.type as optional for now, with unset values treated as the default value (0, Reply) for backward compatibility. To match that behavior, MessageReference.Type now exposes the field and assumes the default when it is missing.

Docs: https://docs.discord.com/developers/resources/message#message-reference-structure