### PR TITLE
Fixed a potential WebSocketException crash that would print to console without getting logged by the logger first.

### DIFF
--- a/NetCord/Gateway/GatewayClient.cs
+++ b/NetCord/Gateway/GatewayClient.cs
@@ -5,6 +5,7 @@ using NetCord.Gateway.JsonModels;
 using NetCord.Gateway.WebSockets;
 using NetCord.Logging;
 
+using WebSocketException = System.Net.WebSockets.WebSocketException;
 using WebSocketCloseStatus = System.Net.WebSockets.WebSocketCloseStatus;
 
 namespace NetCord.Gateway;
@@ -916,8 +917,18 @@ public sealed partial class GatewayClient : WebSocketClient, IEntity
     /// <returns></returns>
     public async ValueTask StartAsync(PresenceProperties? presence = null, CancellationToken cancellationToken = default)
     {
-        var connectionState = await StartAsync(new State(), cancellationToken).ConfigureAwait(false);
-        await SendIdentifyAsync(connectionState, presence, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var connectionState = await StartAsync(new State(), cancellationToken).ConfigureAwait(false);
+            await SendIdentifyAsync(connectionState, presence, cancellationToken).ConfigureAwait(false);
+        }
+        catch (WebSocketException ex)
+        {
+            Log<object?>(LogLevel.Error, null, ex, static (s, e) =>
+            {
+                return $"An error occurred while starting the gateway client.{Environment.NewLine}{e}";
+            });
+        }
     }
 
     /// <summary>
@@ -929,8 +940,18 @@ public sealed partial class GatewayClient : WebSocketClient, IEntity
     /// <returns></returns>
     public async ValueTask ResumeAsync(string sessionId, int sequenceNumber, CancellationToken cancellationToken = default)
     {
-        var connectionState = await StartAsync(new State(), cancellationToken).ConfigureAwait(false);
-        await TryResumeAsync(connectionState, SessionId = sessionId, SequenceNumber = sequenceNumber, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var connectionState = await StartAsync(new State(), cancellationToken).ConfigureAwait(false);
+            await TryResumeAsync(connectionState, SessionId = sessionId, SequenceNumber = sequenceNumber, cancellationToken).ConfigureAwait(false);
+        }
+        catch (WebSocketException ex)
+        {
+            Log<object?>(LogLevel.Error, null, ex, static (s, e) =>
+            {
+                return $"An error occurred while resuming.{Environment.NewLine}{e}";
+            });
+        }
     }
 
     private protected override bool Reconnect(WebSocketCloseStatus? status, string? description)

--- a/NetCord/Gateway/GatewayClient.cs
+++ b/NetCord/Gateway/GatewayClient.cs
@@ -928,6 +928,7 @@ public sealed partial class GatewayClient : WebSocketClient, IEntity
             {
                 return $"An error occurred while starting the gateway client.{Environment.NewLine}{e}";
             });
+            throw;
         }
     }
 
@@ -951,6 +952,7 @@ public sealed partial class GatewayClient : WebSocketClient, IEntity
             {
                 return $"An error occurred while resuming.{Environment.NewLine}{e}";
             });
+            throw;
         }
     }
 


### PR DESCRIPTION
This fixes a potential WebSocketException crash that would print to console without getting logged via the logger when the user just so happens to lose internet (say router gets rebooted by ISP) right when Discord wants ``ResumeAsync`` to be called. This also fixes the issue at startup as well where the user unfortunately gets hit by this as soon as they start their bot, but just before any attempt is made to connect to discord (there is a small window between ``Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.RunAsync(IHost host, CancellationToken token)`` and ``NetCord.Gateway.GatewayClient.StartAsync(PresenceProperties presence, CancellationToken cancellationToken)`` prior to the call to ``StartAsync`` in WebSocketClient.

The fix here is to instead log the exceptions via the logger before rethrowing.