### PR TITLE
Bug fix to allow the calls to webhook APIs to succeed when using GuildThread.

### DIFF
--- a/NetCord/Rest/RestClient.Webhook.cs
+++ b/NetCord/Rest/RestClient.Webhook.cs
@@ -4,9 +4,7 @@ namespace NetCord.Rest;
 
 public partial class RestClient
 {
-    // this seems to work but lacks the "new" in the generated member in GuildThread
-    // to hide the version from TextGuildChannel.
-    [GenerateAlias([typeof(GuildThread)], $"(ulong){nameof(TextGuildChannel.ParentId)}!")]
+    [GenerateAlias([typeof(GuildThread)], $"(ulong){nameof(TextGuildChannel.ParentId)}!", Modifiers = ["new"])]
     [GenerateAlias([typeof(ForumGuildChannel)], nameof(ForumGuildChannel.Id))]
     [GenerateAlias([typeof(TextGuildChannel)], nameof(TextGuildChannel.Id))]
     public async Task<IncomingWebhook> CreateWebhookAsync(ulong channelId, WebhookProperties webhookProperties, RestRequestProperties? properties = null, CancellationToken cancellationToken = default)
@@ -15,9 +13,7 @@ public partial class RestClient
             return new(await (await SendRequestAsync(HttpMethod.Post, content, $"/channels/{channelId}/webhooks", null, new(channelId), properties, cancellationToken: cancellationToken).ConfigureAwait(false)).ToObjectAsync(Serialization.Default.JsonWebhook).ConfigureAwait(false), this);
     }
 
-    // this seems to work but lacks the "new" in the generated member in GuildThread
-    // to hide the version from TextGuildChannel.
-    [GenerateAlias([typeof(GuildThread)], $"(ulong){nameof(TextGuildChannel.ParentId)}!")]
+    [GenerateAlias([typeof(GuildThread)], $"(ulong){nameof(TextGuildChannel.ParentId)}!", Modifiers = ["new"])]
     [GenerateAlias([typeof(ForumGuildChannel)], nameof(ForumGuildChannel.Id))]
     [GenerateAlias([typeof(TextGuildChannel)], nameof(TextGuildChannel.Id))]
     public async Task<IReadOnlyList<Webhook>> GetChannelWebhooksAsync(ulong channelId, RestRequestProperties? properties = null, CancellationToken cancellationToken = default)

--- a/NetCord/Rest/RestClient.Webhook.cs
+++ b/NetCord/Rest/RestClient.Webhook.cs
@@ -4,16 +4,22 @@ namespace NetCord.Rest;
 
 public partial class RestClient
 {
-    [GenerateAlias([typeof(ForumGuildChannel)], $"{nameof(ForumGuildChannel.ParentId)} ?? {nameof(ForumGuildChannel.Id)}")]
-    [GenerateAlias([typeof(TextGuildChannel)], $"{nameof(TextGuildChannel.ParentId)} ?? {nameof(TextGuildChannel.Id)}")]
+    // this seems to work but lacks the "new" in the generated member in GuildThread
+    // to hide the version from TextGuildChannel.
+    [GenerateAlias([typeof(GuildThread)], $"(ulong){nameof(TextGuildChannel.ParentId)}!")]
+    [GenerateAlias([typeof(ForumGuildChannel)], nameof(ForumGuildChannel.Id))]
+    [GenerateAlias([typeof(TextGuildChannel)], nameof(TextGuildChannel.Id))]
     public async Task<IncomingWebhook> CreateWebhookAsync(ulong channelId, WebhookProperties webhookProperties, RestRequestProperties? properties = null, CancellationToken cancellationToken = default)
     {
         using (HttpContent content = new JsonContent<WebhookProperties>(webhookProperties, Serialization.Default.WebhookProperties))
             return new(await (await SendRequestAsync(HttpMethod.Post, content, $"/channels/{channelId}/webhooks", null, new(channelId), properties, cancellationToken: cancellationToken).ConfigureAwait(false)).ToObjectAsync(Serialization.Default.JsonWebhook).ConfigureAwait(false), this);
     }
 
-    [GenerateAlias([typeof(ForumGuildChannel)], $"{nameof(ForumGuildChannel.ParentId)} ?? {nameof(ForumGuildChannel.Id)}")]
-    [GenerateAlias([typeof(TextGuildChannel)], $"{nameof(TextGuildChannel.ParentId)} ?? {nameof(TextGuildChannel.Id)}")]
+    // this seems to work but lacks the "new" in the generated member in GuildThread
+    // to hide the version from TextGuildChannel.
+    [GenerateAlias([typeof(GuildThread)], $"(ulong){nameof(TextGuildChannel.ParentId)}!")]
+    [GenerateAlias([typeof(ForumGuildChannel)], nameof(ForumGuildChannel.Id))]
+    [GenerateAlias([typeof(TextGuildChannel)], nameof(TextGuildChannel.Id))]
     public async Task<IReadOnlyList<Webhook>> GetChannelWebhooksAsync(ulong channelId, RestRequestProperties? properties = null, CancellationToken cancellationToken = default)
         => (await (await SendRequestAsync(HttpMethod.Get, $"/channels/{channelId}/webhooks", null, new(channelId), properties, cancellationToken: cancellationToken).ConfigureAwait(false)).ToObjectAsync(Serialization.Default.JsonWebhookArray).ConfigureAwait(false)).Select(w => Webhook.CreateFromJson(w, this)).ToArray();
 

--- a/NetCord/Rest/RestClient.Webhook.cs
+++ b/NetCord/Rest/RestClient.Webhook.cs
@@ -4,16 +4,16 @@ namespace NetCord.Rest;
 
 public partial class RestClient
 {
-    [GenerateAlias([typeof(ForumGuildChannel)], nameof(ForumGuildChannel.Id))]
-    [GenerateAlias([typeof(TextGuildChannel)], nameof(TextGuildChannel.Id))]
+    [GenerateAlias([typeof(ForumGuildChannel)], $"{nameof(ForumGuildChannel.ParentId)} ?? {nameof(ForumGuildChannel.Id)}")]
+    [GenerateAlias([typeof(TextGuildChannel)], $"{nameof(TextGuildChannel.ParentId)} ?? {nameof(TextGuildChannel.Id)}")]
     public async Task<IncomingWebhook> CreateWebhookAsync(ulong channelId, WebhookProperties webhookProperties, RestRequestProperties? properties = null, CancellationToken cancellationToken = default)
     {
         using (HttpContent content = new JsonContent<WebhookProperties>(webhookProperties, Serialization.Default.WebhookProperties))
             return new(await (await SendRequestAsync(HttpMethod.Post, content, $"/channels/{channelId}/webhooks", null, new(channelId), properties, cancellationToken: cancellationToken).ConfigureAwait(false)).ToObjectAsync(Serialization.Default.JsonWebhook).ConfigureAwait(false), this);
     }
 
-    [GenerateAlias([typeof(ForumGuildChannel)], nameof(ForumGuildChannel.Id))]
-    [GenerateAlias([typeof(TextGuildChannel)], nameof(TextGuildChannel.Id))]
+    [GenerateAlias([typeof(ForumGuildChannel)], $"{nameof(ForumGuildChannel.ParentId)} ?? {nameof(ForumGuildChannel.Id)}")]
+    [GenerateAlias([typeof(TextGuildChannel)], $"{nameof(TextGuildChannel.ParentId)} ?? {nameof(TextGuildChannel.Id)}")]
     public async Task<IReadOnlyList<Webhook>> GetChannelWebhooksAsync(ulong channelId, RestRequestProperties? properties = null, CancellationToken cancellationToken = default)
         => (await (await SendRequestAsync(HttpMethod.Get, $"/channels/{channelId}/webhooks", null, new(channelId), properties, cancellationToken: cancellationToken).ConfigureAwait(false)).ToObjectAsync(Serialization.Default.JsonWebhookArray).ConfigureAwait(false)).Select(w => Webhook.CreateFromJson(w, this)).ToArray();
 


### PR DESCRIPTION
This fixes a bug where when using classes based on GuildThread (ones that most likely inherits from it), because GuildThread inherits from TextGuildChannel the inherited CreateWebhookAsync and the GetChannelWebhooksAsync methods would pass in only the Id (which for normal channels works), but for threads this would always fail as the thread Id would be used as a channel Id and Discord's API does not consider them to be valid channels. As such it is better to attempt to use ParentId (if not null), otherwise use Id (if ParentId is null).