### PR TITLE
XResultHandler should expose MessageProperties creation

### DIFF
--- a/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandInteractionHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandInteractionHandler.cs
@@ -48,7 +48,7 @@ internal unsafe partial class ApplicationCommandInteractionHandler<TInteraction,
             _handleAsync = &HandleInteractionAsync;
 
         _createContext = optionsValue.CreateContext ?? ContextHelper.CreateContextDelegate<TInteraction, GatewayClient?, TContext>(_applicationCommandService.Configuration.ServiceResolverProvider);
-        _resultHandler = optionsValue.ResultHandler ?? new ApplicationCommandResultHandler<TContext>();
+        _resultHandler = optionsValue.ResultHandler ?? ApplicationCommandResultHandler<TContext>.Default;
         _preExecutionHandler = optionsValue.PreExecutionHandler ?? new ApplicationCommandPreExecutionHandler<TContext>();
         _client = client;
     }

--- a/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
@@ -7,22 +7,20 @@ using NetCord.Services.ApplicationCommands;
 
 namespace NetCord.Hosting.Services.ApplicationCommands;
 
-public class ApplicationCommandResultHandler<TContext>
-    : IApplicationCommandResultHandler<TContext>
+public class ApplicationCommandResultHandler<TContext> : IApplicationCommandResultHandler<TContext>
     where TContext : IApplicationCommandContext
 {
     public static ApplicationCommandResultHandler<TContext> Default => new();
 
-    public static ApplicationCommandResultHandler<TContext> Ephemeral => new EphemeralApplicationCommandResultHandler<TContext>();
+    public static ApplicationCommandResultHandler<TContext> Ephemeral => new EphemeralApplicationCommandResultHandler();
 
     protected ApplicationCommandResultHandler()
     {
     }
 
-    private sealed class EphemeralApplicationCommandResultHandler<T> : ApplicationCommandResultHandler<T>
-        where T : IApplicationCommandContext
+    private sealed class EphemeralApplicationCommandResultHandler : ApplicationCommandResultHandler<TContext>
     {
-        public override ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, T context, IServiceProvider services)
+        public override ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, TContext context, IServiceProvider services)
         {
             return new(new InteractionMessageProperties
             {

--- a/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
@@ -25,7 +25,7 @@ public class ApplicationCommandResultHandler<TContext>
         public override InteractionMessageProperties GetFailMessage(IFailResult failResult, T context, IServiceProvider services)
         {
             var message = base.GetFailMessage(failResult, context, services);
-            message.WithFlags(MessageFlags.Ephemeral);
+            message.Flags = MessageFlags.Ephemeral;
             return message;
         }
     }

--- a/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
@@ -19,7 +19,7 @@ public class ApplicationCommandResultHandler<TContext>
     {
     }
 
-    private class EphemeralApplicationCommandResultHandler<T> : ApplicationCommandResultHandler<T>
+    private sealed class EphemeralApplicationCommandResultHandler<T> : ApplicationCommandResultHandler<T>
         where T : IApplicationCommandContext
     {
         public override ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, T context, IServiceProvider services)

--- a/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
@@ -11,11 +11,9 @@ public class ApplicationCommandResultHandler<TContext>
     : IApplicationCommandResultHandler<TContext>
     where TContext : IApplicationCommandContext
 {
-    public static ApplicationCommandResultHandler<TContext> Ephemeral 
-        => new EphemeralApplicationCommandResultHandler<TContext>();
+    public static ApplicationCommandResultHandler<TContext> Default => new();
 
-    public static ApplicationCommandResultHandler<TContext> Default 
-        => new();
+    public static ApplicationCommandResultHandler<TContext> Ephemeral => new EphemeralApplicationCommandResultHandler<TContext>();
 
     protected ApplicationCommandResultHandler()
     {

--- a/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
@@ -22,11 +22,13 @@ public class ApplicationCommandResultHandler<TContext>
     private class EphemeralApplicationCommandResultHandler<T> : ApplicationCommandResultHandler<T>
         where T : IApplicationCommandContext
     {
-        public override async ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, T context, IServiceProvider services)
+        public override ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, T context, IServiceProvider services)
         {
-            var message = await base.GetFailMessageAsync(failResult, context, services).ConfigureAwait(false);
-            message.Flags = MessageFlags.Ephemeral;
-            return message;
+            return new(new InteractionMessageProperties
+            {
+                Content = failResult.Message,
+                Flags = MessageFlags.Ephemeral,
+            });
         }
     }
 

--- a/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
@@ -11,6 +11,27 @@ public class ApplicationCommandResultHandler<TContext>
     : IApplicationCommandResultHandler<TContext>
     where TContext : IApplicationCommandContext
 {
+    public static ApplicationCommandResultHandler<TContext> Ephemeral 
+        => new EphemeralApplicationCommandResultHandler<TContext>();
+
+    public static ApplicationCommandResultHandler<TContext> Default 
+        => new();
+
+    protected ApplicationCommandResultHandler()
+    {
+    }
+
+    internal class EphemeralApplicationCommandResultHandler<T> : ApplicationCommandResultHandler<T>
+        where T : IApplicationCommandContext
+    {
+        public override InteractionMessageProperties GetFailMessage(IFailResult failResult, T context, IServiceProvider services)
+        {
+            var message = base.GetFailMessage(failResult, context, services);
+            message.WithFlags(MessageFlags.Ephemeral);
+            return message;
+        }
+    }
+
     public ValueTask HandleResultAsync(IExecutionResult result, TContext context, GatewayClient? client, ILogger logger, IServiceProvider services)
     {
         if (result is not IFailResult failResult)

--- a/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
@@ -37,18 +37,18 @@ public class ApplicationCommandResultHandler<TContext>
         if (result is not IFailResult failResult)
             return;
 
-        var resultMessage = failResult.Message;
-
         var interaction = context.Interaction;
 
+        var commandName = interaction.Data.Name;
+
         if (failResult is IExceptionResult exceptionResult)
-            logger.LogError(exceptionResult.Exception, "Execution of an application command of name '{Name}' failed with an exception", interaction.Data.Name);
+            logger.LogError(exceptionResult.Exception, "Execution of an application command of name '{Name}' failed with an exception", commandName);
         else
-            logger.LogDebug("Execution of an application command of name '{Name}' failed with '{Message}'", interaction.Data.Name, resultMessage);
+            logger.LogDebug("Execution of an application command of name '{Name}' failed with '{Message}'", commandName, failResult.Message);
 
-        var messageProperties = await GetFailMessageAsync(failResult, context, services).ConfigureAwait(false);
+        var response = await GetFailMessageAsync(failResult, context, services).ConfigureAwait(false);
 
-        await interaction.SendResponseAsync(InteractionCallback.Message(messageProperties)).ConfigureAwait(false);
+        await interaction.SendResponseAsync(InteractionCallback.Message(response)).ConfigureAwait(false);
     }
 
     public virtual ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, TContext context, IServiceProvider services)

--- a/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
@@ -7,7 +7,7 @@ using NetCord.Services.ApplicationCommands;
 
 namespace NetCord.Hosting.Services.ApplicationCommands;
 
-public class ApplicationCommandResultHandler<TContext>(MessageFlags? messageFlags = null)
+public class ApplicationCommandResultHandler<TContext>
     : IApplicationCommandResultHandler<TContext>
     where TContext : IApplicationCommandContext
 {
@@ -25,12 +25,16 @@ public class ApplicationCommandResultHandler<TContext>(MessageFlags? messageFlag
         else
             logger.LogDebug("Execution of an application command of name '{Name}' failed with '{Message}'", interaction.Data.Name, resultMessage);
 
-        InteractionMessageProperties message = new()
-        {
-            Content = resultMessage,
-            Flags = messageFlags,
-        };
+        var messageProperties = GetFailMessage(failResult, context, services);
 
-        return new(interaction.SendResponseAsync(InteractionCallback.Message(message)));
+        return new(interaction.SendResponseAsync(InteractionCallback.Message(messageProperties)));
+    }
+
+    public virtual InteractionMessageProperties GetFailMessage(IFailResult failResult, TContext context, IServiceProvider services)
+    {
+        return new()
+        {
+            Content = failResult.Message,
+        };
     }
 }

--- a/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
@@ -19,7 +19,7 @@ public class ApplicationCommandResultHandler<TContext>
     {
     }
 
-    internal class EphemeralApplicationCommandResultHandler<T> : ApplicationCommandResultHandler<T>
+    private class EphemeralApplicationCommandResultHandler<T> : ApplicationCommandResultHandler<T>
         where T : IApplicationCommandContext
     {
         public override InteractionMessageProperties GetFailMessage(IFailResult failResult, T context, IServiceProvider services)

--- a/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ApplicationCommands/ApplicationCommandResultHandler.cs
@@ -22,18 +22,18 @@ public class ApplicationCommandResultHandler<TContext>
     private class EphemeralApplicationCommandResultHandler<T> : ApplicationCommandResultHandler<T>
         where T : IApplicationCommandContext
     {
-        public override InteractionMessageProperties GetFailMessage(IFailResult failResult, T context, IServiceProvider services)
+        public override async ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, T context, IServiceProvider services)
         {
-            var message = base.GetFailMessage(failResult, context, services);
+            var message = await base.GetFailMessageAsync(failResult, context, services).ConfigureAwait(false);
             message.Flags = MessageFlags.Ephemeral;
             return message;
         }
     }
 
-    public ValueTask HandleResultAsync(IExecutionResult result, TContext context, GatewayClient? client, ILogger logger, IServiceProvider services)
+    public async ValueTask HandleResultAsync(IExecutionResult result, TContext context, GatewayClient? client, ILogger logger, IServiceProvider services)
     {
         if (result is not IFailResult failResult)
-            return default;
+            return;
 
         var resultMessage = failResult.Message;
 
@@ -44,16 +44,16 @@ public class ApplicationCommandResultHandler<TContext>
         else
             logger.LogDebug("Execution of an application command of name '{Name}' failed with '{Message}'", interaction.Data.Name, resultMessage);
 
-        var messageProperties = GetFailMessage(failResult, context, services);
+        var messageProperties = await GetFailMessageAsync(failResult, context, services).ConfigureAwait(false);
 
-        return new(interaction.SendResponseAsync(InteractionCallback.Message(messageProperties)));
+        await interaction.SendResponseAsync(InteractionCallback.Message(messageProperties)).ConfigureAwait(false);
     }
 
-    public virtual InteractionMessageProperties GetFailMessage(IFailResult failResult, TContext context, IServiceProvider services)
+    public virtual ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, TContext context, IServiceProvider services)
     {
-        return new()
+        return new(new InteractionMessageProperties
         {
             Content = failResult.Message,
-        };
+        });
     }
 }

--- a/Hosting/NetCord.Hosting.Services/Commands/CommandHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/Commands/CommandHandler.cs
@@ -49,7 +49,7 @@ internal partial class CommandHandler<[DAM(DAMT.PublicConstructors)] TContext>
 
         _getCommandTextAsync = GetGetCommandTextAsyncDelegate(optionsValue);
         _createContext = optionsValue.CreateContext ?? ContextHelper.CreateContextDelegate<Message, GatewayClient, TContext>(_commandService.Configuration.ServiceResolverProvider);
-        _resultHandler = optionsValue.ResultHandler ?? new CommandResultHandler<TContext>();
+        _resultHandler = optionsValue.ResultHandler ?? CommandResultHandler<TContext>.Default;
         _preExecutionHandler = optionsValue.PreExecutionHandler ?? new CommandPreExecutionHandler<TContext>();
         _client = client;
     }

--- a/Hosting/NetCord.Hosting.Services/Commands/CommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/Commands/CommandResultHandler.cs
@@ -10,6 +10,13 @@ namespace NetCord.Hosting.Services.Commands;
 public class CommandResultHandler<TContext> : ICommandResultHandler<TContext>
     where TContext : ICommandContext
 {
+    public static CommandResultHandler<TContext> Default
+        => new();
+
+    protected CommandResultHandler()
+    {
+    }
+
     public ValueTask HandleResultAsync(IExecutionResult result, TContext context, GatewayClient client, ILogger logger, IServiceProvider services)
     {
         if (result is not IFailResult failResult)

--- a/Hosting/NetCord.Hosting.Services/Commands/CommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/Commands/CommandResultHandler.cs
@@ -10,8 +10,7 @@ namespace NetCord.Hosting.Services.Commands;
 public class CommandResultHandler<TContext> : ICommandResultHandler<TContext>
     where TContext : ICommandContext
 {
-    public static CommandResultHandler<TContext> Default
-        => new();
+    public static CommandResultHandler<TContext> Default => new();
 
     protected CommandResultHandler()
     {

--- a/Hosting/NetCord.Hosting.Services/Commands/CommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/Commands/CommandResultHandler.cs
@@ -1,12 +1,13 @@
 using Microsoft.Extensions.Logging;
 
 using NetCord.Gateway;
+using NetCord.Rest;
 using NetCord.Services;
 using NetCord.Services.Commands;
 
 namespace NetCord.Hosting.Services.Commands;
 
-public class CommandResultHandler<TContext>(MessageFlags? messageFlags = null) : ICommandResultHandler<TContext>
+public class CommandResultHandler<TContext> : ICommandResultHandler<TContext>
     where TContext : ICommandContext
 {
     public ValueTask HandleResultAsync(IExecutionResult result, TContext context, GatewayClient client, ILogger logger, IServiceProvider services)
@@ -14,20 +15,24 @@ public class CommandResultHandler<TContext>(MessageFlags? messageFlags = null) :
         if (result is not IFailResult failResult)
             return default;
 
-        var resultMessage = failResult.Message;
-
         var message = context.Message;
 
         if (failResult is IExceptionResult exceptionResult)
             logger.LogError(exceptionResult.Exception, "Execution of a command with content '{Content}' failed with an exception", message.Content);
         else
-            logger.LogDebug("Execution of a command with content '{Content}' failed with '{Message}'", message.Content, resultMessage);
+            logger.LogDebug("Execution of a command with content '{Content}' failed with '{Message}'", message.Content, failResult.Message);
 
-        return new(message.ReplyAsync(new()
+        var messageProperties = GetFailMessage(failResult, context, services);
+
+        return new(client.Rest.SendMessageAsync(message.ChannelId, messageProperties));
+    }
+
+    public virtual MessageProperties GetFailMessage(IFailResult failResult, TContext context, IServiceProvider services)
+    {
+        return new()
         {
-            Content = resultMessage,
-            FailIfNotExists = false,
-            Flags = messageFlags,
-        }));
+            MessageReference = MessageReferenceProperties.Reply(context.Message.Id, false),
+            Content = failResult.Message,
+        };
     }
 }

--- a/Hosting/NetCord.Hosting.Services/Commands/CommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/Commands/CommandResultHandler.cs
@@ -16,10 +16,10 @@ public class CommandResultHandler<TContext> : ICommandResultHandler<TContext>
     {
     }
 
-    public ValueTask HandleResultAsync(IExecutionResult result, TContext context, GatewayClient client, ILogger logger, IServiceProvider services)
+    public async ValueTask HandleResultAsync(IExecutionResult result, TContext context, GatewayClient client, ILogger logger, IServiceProvider services)
     {
         if (result is not IFailResult failResult)
-            return default;
+            return;
 
         var message = context.Message;
 
@@ -28,17 +28,17 @@ public class CommandResultHandler<TContext> : ICommandResultHandler<TContext>
         else
             logger.LogDebug("Execution of a command with content '{Content}' failed with '{Message}'", message.Content, failResult.Message);
 
-        var messageProperties = GetFailMessage(failResult, context, services);
+        var messageProperties = await GetFailMessage(failResult, context, services).ConfigureAwait(false);
 
-        return new(client.Rest.SendMessageAsync(message.ChannelId, messageProperties));
+        await client.Rest.SendMessageAsync(message.ChannelId, messageProperties).ConfigureAwait(false);
     }
 
-    public virtual MessageProperties GetFailMessage(IFailResult failResult, TContext context, IServiceProvider services)
+    public virtual ValueTask<MessageProperties> GetFailMessage(IFailResult failResult, TContext context, IServiceProvider services)
     {
-        return new()
+        return new(new MessageProperties
         {
             MessageReference = MessageReferenceProperties.Reply(context.Message.Id, false),
             Content = failResult.Message,
-        };
+        });
     }
 }

--- a/Hosting/NetCord.Hosting.Services/Commands/CommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/Commands/CommandResultHandler.cs
@@ -23,14 +23,16 @@ public class CommandResultHandler<TContext> : ICommandResultHandler<TContext>
 
         var message = context.Message;
 
+        var messageContent = message.Content;
+
         if (failResult is IExceptionResult exceptionResult)
-            logger.LogError(exceptionResult.Exception, "Execution of a command with content '{Content}' failed with an exception", message.Content);
+            logger.LogError(exceptionResult.Exception, "Execution of a command with content '{Content}' failed with an exception", messageContent);
         else
-            logger.LogDebug("Execution of a command with content '{Content}' failed with '{Message}'", message.Content, failResult.Message);
+            logger.LogDebug("Execution of a command with content '{Content}' failed with '{Message}'", messageContent, failResult.Message);
 
-        var messageProperties = await GetFailMessage(failResult, context, services).ConfigureAwait(false);
+        var response = await GetFailMessage(failResult, context, services).ConfigureAwait(false);
 
-        await message.SendAsync(messageProperties).ConfigureAwait(false);
+        await message.SendAsync(response).ConfigureAwait(false);
     }
 
     public virtual ValueTask<MessageProperties> GetFailMessage(IFailResult failResult, TContext context, IServiceProvider services)

--- a/Hosting/NetCord.Hosting.Services/Commands/CommandResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/Commands/CommandResultHandler.cs
@@ -30,7 +30,7 @@ public class CommandResultHandler<TContext> : ICommandResultHandler<TContext>
 
         var messageProperties = await GetFailMessage(failResult, context, services).ConfigureAwait(false);
 
-        await client.Rest.SendMessageAsync(message.ChannelId, messageProperties).ConfigureAwait(false);
+        await message.SendAsync(messageProperties).ConfigureAwait(false);
     }
 
     public virtual ValueTask<MessageProperties> GetFailMessage(IFailResult failResult, TContext context, IServiceProvider services)

--- a/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionHandler.cs
@@ -49,7 +49,7 @@ internal unsafe partial class ComponentInteractionHandler<TInteraction, [DAM(DAM
             _handleAsync = &HandleInteractionAsync;
 
         _createContext = optionsValue.CreateContext ?? ContextHelper.CreateContextDelegate<TInteraction, GatewayClient?, TContext>(_componentInteractionService.Configuration.ServiceResolverProvider);
-        _resultHandler = optionsValue.ResultHandler ?? new ComponentInteractionResultHandler<TContext>();
+        _resultHandler = optionsValue.ResultHandler ?? ComponentInteractionResultHandler<TContext>.Default;
         _preExecutionHandler = optionsValue.PreExecutionHandler ?? new ComponentInteractionPreExecutionHandler<TContext>();
         _client = client;
     }

--- a/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
@@ -1,8 +1,10 @@
 using Microsoft.Extensions.Logging;
 
 using NetCord.Gateway;
+using NetCord.Hosting.Services.ApplicationCommands;
 using NetCord.Rest;
 using NetCord.Services;
+using NetCord.Services.ApplicationCommands;
 using NetCord.Services.ComponentInteractions;
 
 namespace NetCord.Hosting.Services.ComponentInteractions;
@@ -11,6 +13,27 @@ public class ComponentInteractionResultHandler<TContext>
     : IComponentInteractionResultHandler<TContext>
     where TContext : IComponentInteractionContext
 {
+    public static ComponentInteractionResultHandler<TContext> Ephemeral
+        => new EphemeralComponentInteractionResultHandler<TContext>();
+
+    public static ComponentInteractionResultHandler<TContext> Default
+        => new();
+
+    protected ComponentInteractionResultHandler()
+    {
+    }
+
+    internal class EphemeralComponentInteractionResultHandler<T> : ComponentInteractionResultHandler<T>
+        where T : IComponentInteractionContext
+    {
+        public override InteractionMessageProperties GetFailMessage(IFailResult failResult, T context, IServiceProvider services)
+        {
+            var message = base.GetFailMessage(failResult, context, services);
+            message.WithFlags(MessageFlags.Ephemeral);
+            return message;
+        }
+    }
+
     public ValueTask HandleResultAsync(IExecutionResult result, TContext context, GatewayClient? client, ILogger logger, IServiceProvider services)
     {
         if (result is not IFailResult failResult)

--- a/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
@@ -19,7 +19,7 @@ public class ComponentInteractionResultHandler<TContext>
     {
     }
 
-    private class EphemeralComponentInteractionResultHandler<T> : ComponentInteractionResultHandler<T>
+    private sealed class EphemeralComponentInteractionResultHandler<T> : ComponentInteractionResultHandler<T>
         where T : IComponentInteractionContext
     {
         public override ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, T context, IServiceProvider services)

--- a/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
@@ -1,10 +1,8 @@
 using Microsoft.Extensions.Logging;
 
 using NetCord.Gateway;
-using NetCord.Hosting.Services.ApplicationCommands;
 using NetCord.Rest;
 using NetCord.Services;
-using NetCord.Services.ApplicationCommands;
 using NetCord.Services.ComponentInteractions;
 
 namespace NetCord.Hosting.Services.ComponentInteractions;
@@ -24,18 +22,18 @@ public class ComponentInteractionResultHandler<TContext>
     private class EphemeralComponentInteractionResultHandler<T> : ComponentInteractionResultHandler<T>
         where T : IComponentInteractionContext
     {
-        public override InteractionMessageProperties GetFailMessage(IFailResult failResult, T context, IServiceProvider services)
+        public override async ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, T context, IServiceProvider services)
         {
-            var message = base.GetFailMessage(failResult, context, services);
+            var message = await base.GetFailMessageAsync(failResult, context, services).ConfigureAwait(false);
             message.Flags = MessageFlags.Ephemeral;
             return message;
         }
     }
 
-    public ValueTask HandleResultAsync(IExecutionResult result, TContext context, GatewayClient? client, ILogger logger, IServiceProvider services)
+    public async ValueTask HandleResultAsync(IExecutionResult result, TContext context, GatewayClient? client, ILogger logger, IServiceProvider services)
     {
         if (result is not IFailResult failResult)
-            return default;
+            return;
 
         var resultMessage = failResult.Message;
 
@@ -46,16 +44,16 @@ public class ComponentInteractionResultHandler<TContext>
         else
             logger.LogDebug("Execution of an interaction of custom ID '{Id}' failed with '{Message}'", interaction.Data.CustomId, resultMessage);
 
-        var messageProperties = GetFailMessage(failResult, context, services);
+        var messageProperties = await GetFailMessageAsync(failResult, context, services).ConfigureAwait(false);
 
-        return new(interaction.SendResponseAsync(InteractionCallback.Message(messageProperties)));
+        await interaction.SendResponseAsync(InteractionCallback.Message(messageProperties)).ConfigureAwait(false);
     }
 
-    public virtual InteractionMessageProperties GetFailMessage(IFailResult failResult, TContext context, IServiceProvider services)
+    public virtual ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, TContext context, IServiceProvider services)
     {
-        return new()
+        return new(new InteractionMessageProperties
         {
             Content = failResult.Message,
-        };
+        });
     }
 }

--- a/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
@@ -22,11 +22,13 @@ public class ComponentInteractionResultHandler<TContext>
     private class EphemeralComponentInteractionResultHandler<T> : ComponentInteractionResultHandler<T>
         where T : IComponentInteractionContext
     {
-        public override async ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, T context, IServiceProvider services)
+        public override ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, T context, IServiceProvider services)
         {
-            var message = await base.GetFailMessageAsync(failResult, context, services).ConfigureAwait(false);
-            message.Flags = MessageFlags.Ephemeral;
-            return message;
+            return new(new InteractionMessageProperties
+            {
+                Content = failResult.Message,
+                Flags = MessageFlags.Ephemeral,
+            });
         }
     }
 

--- a/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
@@ -13,11 +13,9 @@ public class ComponentInteractionResultHandler<TContext>
     : IComponentInteractionResultHandler<TContext>
     where TContext : IComponentInteractionContext
 {
-    public static ComponentInteractionResultHandler<TContext> Ephemeral
-        => new EphemeralComponentInteractionResultHandler<TContext>();
+    public static ComponentInteractionResultHandler<TContext> Default => new();
 
-    public static ComponentInteractionResultHandler<TContext> Default
-        => new();
+    public static ComponentInteractionResultHandler<TContext> Ephemeral => new EphemeralComponentInteractionResultHandler<TContext>();
 
     protected ComponentInteractionResultHandler()
     {

--- a/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
@@ -7,7 +7,8 @@ using NetCord.Services.ComponentInteractions;
 
 namespace NetCord.Hosting.Services.ComponentInteractions;
 
-public class ComponentInteractionResultHandler<TContext>(MessageFlags? messageFlags = null) : IComponentInteractionResultHandler<TContext>
+public class ComponentInteractionResultHandler<TContext> 
+    : IComponentInteractionResultHandler<TContext>
     where TContext : IComponentInteractionContext
 {
     public ValueTask HandleResultAsync(IExecutionResult result, TContext context, GatewayClient? client, ILogger logger, IServiceProvider services)
@@ -24,12 +25,16 @@ public class ComponentInteractionResultHandler<TContext>(MessageFlags? messageFl
         else
             logger.LogDebug("Execution of an interaction of custom ID '{Id}' failed with '{Message}'", interaction.Data.CustomId, resultMessage);
 
-        InteractionMessageProperties message = new()
-        {
-            Content = resultMessage,
-            Flags = messageFlags,
-        };
+        var messageProperties = GetFailMessage(failResult, context, services);
 
-        return new(interaction.SendResponseAsync(InteractionCallback.Message(message)));
+        return new(interaction.SendResponseAsync(InteractionCallback.Message(messageProperties)));
+    }
+
+    public virtual InteractionMessageProperties GetFailMessage(IFailResult failResult, TContext context, IServiceProvider services)
+    {
+        return new()
+        {
+            Content = failResult.Message,
+        };
     }
 }

--- a/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
@@ -23,7 +23,7 @@ public class ComponentInteractionResultHandler<TContext>
     {
     }
 
-    internal class EphemeralComponentInteractionResultHandler<T> : ComponentInteractionResultHandler<T>
+    private class EphemeralComponentInteractionResultHandler<T> : ComponentInteractionResultHandler<T>
         where T : IComponentInteractionContext
     {
         public override InteractionMessageProperties GetFailMessage(IFailResult failResult, T context, IServiceProvider services)

--- a/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
@@ -29,7 +29,7 @@ public class ComponentInteractionResultHandler<TContext>
         public override InteractionMessageProperties GetFailMessage(IFailResult failResult, T context, IServiceProvider services)
         {
             var message = base.GetFailMessage(failResult, context, services);
-            message.WithFlags(MessageFlags.Ephemeral);
+            message.Flags = MessageFlags.Ephemeral;
             return message;
         }
     }

--- a/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
@@ -7,7 +7,7 @@ using NetCord.Services.ComponentInteractions;
 
 namespace NetCord.Hosting.Services.ComponentInteractions;
 
-public class ComponentInteractionResultHandler<TContext> 
+public class ComponentInteractionResultHandler<TContext>
     : IComponentInteractionResultHandler<TContext>
     where TContext : IComponentInteractionContext
 {
@@ -37,18 +37,18 @@ public class ComponentInteractionResultHandler<TContext>
         if (result is not IFailResult failResult)
             return;
 
-        var resultMessage = failResult.Message;
-
         var interaction = context.Interaction;
 
+        var customId = interaction.Data.CustomId;
+
         if (failResult is IExceptionResult exceptionResult)
-            logger.LogError(exceptionResult.Exception, "Execution of an interaction of custom ID '{Id}' failed with an exception", interaction.Data.CustomId);
+            logger.LogError(exceptionResult.Exception, "Execution of an interaction of custom ID '{Id}' failed with an exception", customId);
         else
-            logger.LogDebug("Execution of an interaction of custom ID '{Id}' failed with '{Message}'", interaction.Data.CustomId, resultMessage);
+            logger.LogDebug("Execution of an interaction of custom ID '{Id}' failed with '{Message}'", customId, failResult.Message);
 
-        var messageProperties = await GetFailMessageAsync(failResult, context, services).ConfigureAwait(false);
+        var response = await GetFailMessageAsync(failResult, context, services).ConfigureAwait(false);
 
-        await interaction.SendResponseAsync(InteractionCallback.Message(messageProperties)).ConfigureAwait(false);
+        await interaction.SendResponseAsync(InteractionCallback.Message(response)).ConfigureAwait(false);
     }
 
     public virtual ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, TContext context, IServiceProvider services)

--- a/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
+++ b/Hosting/NetCord.Hosting.Services/ComponentInteractions/ComponentInteractionResultHandler.cs
@@ -7,22 +7,20 @@ using NetCord.Services.ComponentInteractions;
 
 namespace NetCord.Hosting.Services.ComponentInteractions;
 
-public class ComponentInteractionResultHandler<TContext>
-    : IComponentInteractionResultHandler<TContext>
+public class ComponentInteractionResultHandler<TContext> : IComponentInteractionResultHandler<TContext>
     where TContext : IComponentInteractionContext
 {
     public static ComponentInteractionResultHandler<TContext> Default => new();
 
-    public static ComponentInteractionResultHandler<TContext> Ephemeral => new EphemeralComponentInteractionResultHandler<TContext>();
+    public static ComponentInteractionResultHandler<TContext> Ephemeral => new EphemeralComponentInteractionResultHandler();
 
     protected ComponentInteractionResultHandler()
     {
     }
 
-    private sealed class EphemeralComponentInteractionResultHandler<T> : ComponentInteractionResultHandler<T>
-        where T : IComponentInteractionContext
+    private sealed class EphemeralComponentInteractionResultHandler : ComponentInteractionResultHandler<TContext>
     {
-        public override ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, T context, IServiceProvider services)
+        public override ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, TContext context, IServiceProvider services)
         {
             return new(new InteractionMessageProperties
             {

--- a/Tests/NetCord.Test.Hosting/CustomApplicationCommandResultHandler.cs
+++ b/Tests/NetCord.Test.Hosting/CustomApplicationCommandResultHandler.cs
@@ -1,20 +1,18 @@
-using Microsoft.Extensions.Logging;
-
-using NetCord.Gateway;
 using NetCord.Hosting.Services.ApplicationCommands;
+using NetCord.Rest;
 using NetCord.Services;
 using NetCord.Services.ApplicationCommands;
 
 namespace NetCord.Test.Hosting;
 
-internal class CustomApplicationCommandResultHandler : IApplicationCommandResultHandler<ApplicationCommandContext>
+internal class CustomApplicationCommandResultHandler : ApplicationCommandResultHandler<ApplicationCommandContext>
 {
-    private static readonly ApplicationCommandResultHandler<ApplicationCommandContext> _defaultHandler = new(MessageFlags.Ephemeral);
-
-    public ValueTask HandleResultAsync(IExecutionResult result, ApplicationCommandContext context, GatewayClient? client, ILogger logger, IServiceProvider services)
+    public override InteractionMessageProperties GetFailMessage(IFailResult failResult, ApplicationCommandContext context, IServiceProvider services)
     {
-        logger.LogInformation("Handling result of an application command");
+        var message = base.GetFailMessage(failResult, context, services);
 
-        return _defaultHandler.HandleResultAsync(result, context, client, logger, services);
+        message.WithFlags(MessageFlags.Ephemeral);
+
+        return message;
     }
 }

--- a/Tests/NetCord.Test.Hosting/CustomApplicationCommandResultHandler.cs
+++ b/Tests/NetCord.Test.Hosting/CustomApplicationCommandResultHandler.cs
@@ -11,7 +11,7 @@ internal class CustomApplicationCommandResultHandler : ApplicationCommandResultH
     {
         var message = await base.GetFailMessageAsync(failResult, context, services).ConfigureAwait(false);
 
-        message.WithFlags(MessageFlags.Ephemeral);
+        message.Flags = MessageFlags.Ephemeral;
 
         return message;
     }

--- a/Tests/NetCord.Test.Hosting/CustomApplicationCommandResultHandler.cs
+++ b/Tests/NetCord.Test.Hosting/CustomApplicationCommandResultHandler.cs
@@ -7,9 +7,9 @@ namespace NetCord.Test.Hosting;
 
 internal class CustomApplicationCommandResultHandler : ApplicationCommandResultHandler<ApplicationCommandContext>
 {
-    public override InteractionMessageProperties GetFailMessage(IFailResult failResult, ApplicationCommandContext context, IServiceProvider services)
+    public override async ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, ApplicationCommandContext context, IServiceProvider services)
     {
-        var message = base.GetFailMessage(failResult, context, services);
+        var message = await base.GetFailMessageAsync(failResult, context, services).ConfigureAwait(false);
 
         message.WithFlags(MessageFlags.Ephemeral);
 

--- a/Tests/NetCord.Test.Hosting/CustomApplicationCommandResultHandler.cs
+++ b/Tests/NetCord.Test.Hosting/CustomApplicationCommandResultHandler.cs
@@ -1,18 +1,20 @@
+using Microsoft.Extensions.Logging;
+
+using NetCord.Gateway;
 using NetCord.Hosting.Services.ApplicationCommands;
-using NetCord.Rest;
 using NetCord.Services;
 using NetCord.Services.ApplicationCommands;
 
 namespace NetCord.Test.Hosting;
 
-internal class CustomApplicationCommandResultHandler : ApplicationCommandResultHandler<ApplicationCommandContext>
+internal class CustomApplicationCommandResultHandler : IApplicationCommandResultHandler<ApplicationCommandContext>
 {
-    public override async ValueTask<InteractionMessageProperties> GetFailMessageAsync(IFailResult failResult, ApplicationCommandContext context, IServiceProvider services)
+    private static readonly ApplicationCommandResultHandler<ApplicationCommandContext> _defaultHandler = ApplicationCommandResultHandler<ApplicationCommandContext>.Ephemeral;
+
+    public ValueTask HandleResultAsync(IExecutionResult result, ApplicationCommandContext context, GatewayClient? client, ILogger logger, IServiceProvider services)
     {
-        var message = await base.GetFailMessageAsync(failResult, context, services).ConfigureAwait(false);
+        logger.LogInformation("Handling result of an application command");
 
-        message.Flags = MessageFlags.Ephemeral;
-
-        return message;
+        return _defaultHandler.HandleResultAsync(result, context, client, logger, services);
     }
 }


### PR DESCRIPTION
This PR exposes the `GetFailMessageAsync` function in:

- `ApplicationCommandResultHandler<T>`
- `ComponentInteractionResultHandler<T>`
- `CommandResultHandler<T>`

In order to allow implementations to change or replace the behavior of failure message creation.

Breaking: The `MessageFlags? messageFlags = null` parameter in all three result handler implementations has been removed in favor of implementation-first design for pushing the `MessageProperties.Flags` variable user-side.

An alternative to this approach is considering to expose delegate defaults for these classes, e.g.

```cs
public sealed class DelegateApplicationCommandResultHandler(Func<..., ValueTask> resultDelegate) { ... }
```

```cs
configuration.ResultHandler = new DelegateApplicationCommandResultHandler((...) => { ... });
```