### PR TITLE
Add SlashCommandIgnoreAttribute for hiding enum values from slash commands

### DIFF
--- a/NetCord.Services/ApplicationCommands/SlashCommandIgnoreAttribute.cs
+++ b/NetCord.Services/ApplicationCommands/SlashCommandIgnoreAttribute.cs
@@ -1,0 +1,10 @@
+namespace NetCord.Services.ApplicationCommands;
+
+/// <summary>
+/// Specifies that an enum value should be ignored and not shown as an option in slash commands.
+/// Apply this attribute to enum fields that should not be presented to users as choices.
+/// </summary>
+[AttributeUsage(AttributeTargets.Field)]
+public class SlashCommandIgnoreAttribute : Attribute
+{
+}

--- a/NetCord.Services/EnumTypeReaders/SlashCommandEnumTypeReader.cs
+++ b/NetCord.Services/EnumTypeReaders/SlashCommandEnumTypeReader.cs
@@ -24,10 +24,11 @@ internal class SlashCommandEnumTypeReader<TContext>(Type enumType, FieldInfo[] f
     {
         var localizationsProvider = parameter.LocalizationsProvider;
 
-        var count = fields.Length;
+        var filteredFields = fields.Where(f => f.GetCustomAttribute<SlashCommandIgnoreAttribute>() is null).ToArray();
+        var count = filteredFields.Length;
         var choices = new ApplicationCommandOptionChoiceProperties[count];
         for (var i = 0; i < count; i++)
-            choices[i] = await CreateChoiceAsync(fields[i]).ConfigureAwait(false);
+            choices[i] = await CreateChoiceAsync(filteredFields[i]).ConfigureAwait(false);
 
         return choices;
 

--- a/Tests/ServicesTest/ChoicesAndAutocompleteTests.cs
+++ b/Tests/ServicesTest/ChoicesAndAutocompleteTests.cs
@@ -299,7 +299,7 @@ public class ChoicesAndAutocompleteTests
 
         Assert.IsNotNull(parameter.ChoicesProvider);
 
-        var choices = await parameter.ChoicesProvider.GetChoicesAsync(parameter);
+        var choices = await parameter.ChoicesProvider.GetChoicesAsync(parameter).ConfigureAwait(false);
 
         Assert.IsNotNull(choices);
 

--- a/Tests/ServicesTest/ChoicesAndAutocompleteTests.cs
+++ b/Tests/ServicesTest/ChoicesAndAutocompleteTests.cs
@@ -274,4 +274,39 @@ public class ChoicesAndAutocompleteTests
                 ([SlashCommandParameter(AutocompleteProviderType = typeof(TestAutocompleteProvider))] int i) => { }));
         });
     }
+
+    private enum TestEnumWithIgnoredValues
+    {
+        Value1,
+        [SlashCommandIgnore]
+        Value2,
+        Value3,
+    }
+
+    [TestMethod]
+    public async Task TestEnumIgnoreAttribute()
+    {
+        var service = CreateService();
+
+        service.AddSlashCommand(new SlashCommandBuilder(
+            "test",
+            "Test",
+            (TestEnumWithIgnoredValues e) => { }));
+
+        var command = (SlashCommandInfo<ApplicationCommandContext>)service.GetCommands().Single();
+
+        var parameter = command.Parameters.Single();
+
+        Assert.IsNotNull(parameter.ChoicesProvider);
+
+        var choices = await parameter.ChoicesProvider.GetChoicesAsync(parameter);
+
+        Assert.IsNotNull(choices);
+
+        var choicesList = choices.ToList();
+
+        Assert.AreEqual(2, choicesList.Count);
+        Assert.AreEqual("Value1", choicesList[0].Name);
+        Assert.AreEqual("Value3", choicesList[1].Name);
+    }
 }


### PR DESCRIPTION
## Description

Adds a new  attribute that can be applied to enum fields to exclude them from being shown as options in slash commands.

Closes #330

## Changes

- Added  in 
- Modified  to filter out fields with the attribute
- Added unit test 

## Usage

```csharp
public enum MyEnum
{
    Value1,
    [SlashCommandIgnore]
    None = 0,  // Will not be shown in slash commands
    Value2,
}
```

## Note

The project requires .NET SDK 10.0.301 for source generators which is not available in my local environment, so I was unable to run the full test suite. However, the logic is straightforward and follows the existing pattern used by .